### PR TITLE
Allow decimal separator based on locale.

### DIFF
--- a/app/src/main/java/info/blockchain/wallet/MainActivity.java
+++ b/app/src/main/java/info/blockchain/wallet/MainActivity.java
@@ -1,7 +1,5 @@
 package info.blockchain.wallet;
 
-import com.google.zxing.client.android.CaptureActivity;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Fragment;
@@ -46,7 +44,17 @@ import android.widget.EditText;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.google.zxing.client.android.CaptureActivity;
 import com.squareup.picasso.Picasso;
+
+import org.bitcoinj.core.bip44.WalletFactory;
+
+import java.nio.charset.Charset;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import info.blockchain.wallet.access.AccessFactory;
 import info.blockchain.wallet.drawer.DrawerAdapter;
@@ -69,17 +77,6 @@ import info.blockchain.wallet.util.RootUtil;
 import info.blockchain.wallet.util.SSLVerifierThreadUtil;
 import info.blockchain.wallet.util.ToastCustom;
 import info.blockchain.wallet.util.WebUtil;
-
-import org.bitcoinj.core.bip44.WalletFactory;
-
-import java.nio.charset.Charset;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
-
 import piuk.blockchain.android.R;
 
 //import android.nfc.Tag;
@@ -135,8 +132,6 @@ public class MainActivity extends ActionBarActivity implements CreateNdefMessage
         }
 
         AppUtil.getInstance(MainActivity.this).applyPRNGFixes();
-
-        Locale.setDefault(Locale.US);
 
         if (!ConnectivityStatus.hasConnectivity(this)) {
             final AlertDialog.Builder builder = new AlertDialog.Builder(this);

--- a/app/src/main/java/info/blockchain/wallet/ReceiveFragment.java
+++ b/app/src/main/java/info/blockchain/wallet/ReceiveFragment.java
@@ -1,10 +1,5 @@
 package info.blockchain.wallet;
 
-import com.google.zxing.BarcodeFormat;
-import com.google.zxing.WriterException;
-import com.google.zxing.client.android.Contents;
-import com.google.zxing.client.android.encode.QRCodeEncoder;
-
 import android.app.AlertDialog;
 import android.app.Fragment;
 import android.app.FragmentManager;
@@ -48,18 +43,11 @@ import android.widget.Spinner;
 import android.widget.TableLayout;
 import android.widget.TextView;
 
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.android.Contents;
+import com.google.zxing.client.android.encode.QRCodeEncoder;
 import com.sothree.slidinguppanel.SlidingUpPanelLayout;
-
-import info.blockchain.wallet.callbacks.CustomKeypadCallback;
-import info.blockchain.wallet.payload.LegacyAddress;
-import info.blockchain.wallet.payload.PayloadFactory;
-import info.blockchain.wallet.payload.ReceiveAddress;
-import info.blockchain.wallet.util.AccountsUtil;
-import info.blockchain.wallet.util.AppUtil;
-import info.blockchain.wallet.util.ExchangeRateFactory;
-import info.blockchain.wallet.util.MonetaryUtil;
-import info.blockchain.wallet.util.PrefsUtil;
-import info.blockchain.wallet.util.ToastCustom;
 
 import org.apache.commons.codec.DecoderException;
 import org.bitcoinj.core.AddressFormatException;
@@ -80,6 +68,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import info.blockchain.wallet.callbacks.CustomKeypadCallback;
+import info.blockchain.wallet.payload.LegacyAddress;
+import info.blockchain.wallet.payload.PayloadFactory;
+import info.blockchain.wallet.payload.ReceiveAddress;
+import info.blockchain.wallet.util.AccountsUtil;
+import info.blockchain.wallet.util.AppUtil;
+import info.blockchain.wallet.util.ExchangeRateFactory;
+import info.blockchain.wallet.util.MonetaryUtil;
+import info.blockchain.wallet.util.PrefsUtil;
+import info.blockchain.wallet.util.ToastCustom;
 import piuk.blockchain.android.R;
 
 public class ReceiveFragment extends Fragment implements OnClickListener, CustomKeypadCallback {
@@ -201,6 +199,8 @@ public class ReceiveFragment extends Fragment implements OnClickListener, Custom
         edAmount1.addTextChangedListener(new TextWatcher() {
             public void afterTextChanged(Editable s) {
 
+                String input = s.toString();
+
                 edAmount1.removeTextChangedListener(this);
 
                 int unit = PrefsUtil.getInstance(getActivity()).getValue(PrefsUtil.KEY_BTC_UNITS, MonetaryUtil.UNIT_BTC);
@@ -221,14 +221,12 @@ public class ReceiveFragment extends Fragment implements OnClickListener, Custom
                 btcFormat.setMinimumFractionDigits(0);
 
                 try {
-                    double d = Double.parseDouble(s.toString());
-                    String s1 = btcFormat.format(d);
-                    if (s1.indexOf(defaultSeperator) != -1) {
-                        String dec = s1.substring(s1.indexOf(defaultSeperator));
+                    if (input.indexOf(defaultSeperator) != -1) {
+                        String dec = input.substring(input.indexOf(defaultSeperator));
                         if (dec.length() > 0) {
                             dec = dec.substring(1);
                             if (dec.length() > max_len) {
-                                edAmount1.setText(s1.substring(0, s1.length() - 1));
+                                edAmount1.setText(input.substring(0, input.length() - 1));
                                 edAmount1.setSelection(edAmount1.getText().length());
                                 s = edAmount1.getEditableText();
                             }
@@ -272,6 +270,8 @@ public class ReceiveFragment extends Fragment implements OnClickListener, Custom
 
             public void afterTextChanged(Editable s) {
 
+                String input = s.toString();
+
                 edAmount2.removeTextChangedListener(this);
 
                 int max_len = 2;
@@ -280,14 +280,12 @@ public class ReceiveFragment extends Fragment implements OnClickListener, Custom
                 fiatFormat.setMinimumFractionDigits(0);
 
                 try {
-                    double d = Double.parseDouble(s.toString());
-                    String s1 = fiatFormat.format(d);
-                    if (s1.indexOf(defaultSeperator) != -1) {
-                        String dec = s1.substring(s1.indexOf(defaultSeperator));
+                    if (input.indexOf(defaultSeperator) != -1) {
+                        String dec = input.substring(input.indexOf(defaultSeperator));
                         if (dec.length() > 0) {
                             dec = dec.substring(1);
                             if (dec.length() > max_len) {
-                                edAmount2.setText(s1.substring(0, s1.length() - 1));
+                                edAmount2.setText(input.substring(0, input.length() - 1));
                                 edAmount2.setSelection(edAmount2.getText().length());
                                 s = edAmount2.getEditableText();
                             }
@@ -853,7 +851,7 @@ public class ReceiveFragment extends Fragment implements OnClickListener, Custom
                 pad = v.getTag().toString().substring(0, 1);
                 break;
             case R.id.button10:
-                pad = ".";
+                pad = defaultSeperator;
                 break;
             case R.id.button0:
                 pad = v.getTag().toString().substring(0, 1);

--- a/app/src/main/java/info/blockchain/wallet/SendFragment.java
+++ b/app/src/main/java/info/blockchain/wallet/SendFragment.java
@@ -38,6 +38,23 @@ import android.widget.TableLayout;
 import android.widget.TextView;
 import android.widget.TextView.OnEditorActionListener;
 
+import org.apache.commons.codec.DecoderException;
+import org.bitcoinj.core.AddressFormatException;
+import org.bitcoinj.core.bip44.Wallet;
+import org.bitcoinj.core.bip44.WalletFactory;
+import org.bitcoinj.crypto.MnemonicException;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
 import info.blockchain.wallet.callbacks.CustomKeypadCallback;
 import info.blockchain.wallet.callbacks.OpCallback;
 import info.blockchain.wallet.multiaddr.MultiAddrFactory;
@@ -62,24 +79,6 @@ import info.blockchain.wallet.util.PrefsUtil;
 import info.blockchain.wallet.util.ReselectSpinner;
 import info.blockchain.wallet.util.ToastCustom;
 import info.blockchain.wallet.util.TypefaceUtil;
-
-import org.apache.commons.codec.DecoderException;
-import org.bitcoinj.core.AddressFormatException;
-import org.bitcoinj.core.bip44.Wallet;
-import org.bitcoinj.core.bip44.WalletFactory;
-import org.bitcoinj.crypto.MnemonicException;
-
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.text.NumberFormat;
-import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
-
 import piuk.blockchain.android.R;
 
 //import android.util.Log;
@@ -204,6 +203,8 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
         btcTextWatcher = new TextWatcher() {
             public void afterTextChanged(Editable s) {
 
+                String input = s.toString();
+
                 long lamount = 0L;
                 try {
                     //Long is safe to use, but double can lead to ugly rounding issues..
@@ -241,14 +242,12 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
                 btcFormat.setMinimumFractionDigits(0);
 
                 try {
-                    double d = Double.parseDouble(s.toString());
-                    String s1 = btcFormat.format(d);
-                    if (s1.indexOf(defaultSeparator) != -1) {
-                        String dec = s1.substring(s1.indexOf(defaultSeparator));
+                    if (input.indexOf(defaultSeparator) != -1) {
+                        String dec = input.substring(input.indexOf(defaultSeparator));
                         if (dec.length() > 0) {
                             dec = dec.substring(1);
                             if (dec.length() > max_len) {
-                                edAmount1.setText(s1.substring(0, s1.length() - 1));
+                                edAmount1.setText(input.substring(0, input.length() - 1));
                                 edAmount1.setSelection(edAmount1.getText().length());
                                 s = edAmount1.getEditableText();
                             }
@@ -296,6 +295,8 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
         fiatTextWatcher = new TextWatcher() {
             public void afterTextChanged(Editable s) {
 
+                String input = s.toString();
+
                 edAmount2.removeTextChangedListener(this);
 
                 int max_len = 2;
@@ -304,14 +305,12 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
                 fiatFormat.setMinimumFractionDigits(0);
 
                 try {
-                    double d = Double.parseDouble(s.toString());
-                    String s1 = fiatFormat.format(d);
-                    if (s1.indexOf(defaultSeparator) != -1) {
-                        String dec = s1.substring(s1.indexOf(defaultSeparator));
+                    if (input.indexOf(defaultSeparator) != -1) {
+                        String dec = input.substring(input.indexOf(defaultSeparator));
                         if (dec.length() > 0) {
                             dec = dec.substring(1);
                             if (dec.length() > max_len) {
-                                edAmount2.setText(s1.substring(0, s1.length() - 1));
+                                edAmount2.setText(input.substring(0, input.length() - 1));
                                 edAmount2.setSelection(edAmount2.getText().length());
                                 s = edAmount2.getEditableText();
                             }
@@ -1399,7 +1398,7 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
                 pad = v.getTag().toString().substring(0, 1);
                 break;
             case R.id.button10:
-                pad = ".";
+                pad = defaultSeparator;
                 break;
             case R.id.button0:
                 pad = v.getTag().toString().substring(0, 1);

--- a/app/src/main/java/info/blockchain/wallet/util/MonetaryUtil.java
+++ b/app/src/main/java/info/blockchain/wallet/util/MonetaryUtil.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import java.math.BigInteger;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Currency;
 import java.util.Locale;
@@ -21,8 +22,8 @@ public class MonetaryUtil {
     private static Context context = null;
     private static CharSequence[] btcUnits = {"BTC", "mBTC", "bits"};
     private static MonetaryUtil instance = null;
-    private static NumberFormat btcFormat = null;
-    private static NumberFormat fiatFormat = null;
+    private static DecimalFormat btcFormat = null;
+    private static DecimalFormat fiatFormat = null;
 
     private MonetaryUtil() {
         ;
@@ -31,13 +32,19 @@ public class MonetaryUtil {
     public static MonetaryUtil getInstance() {
 
         if (instance == null) {
-            fiatFormat = NumberFormat.getInstance(Locale.getDefault());
+            fiatFormat = (DecimalFormat)NumberFormat.getInstance(Locale.getDefault());
             fiatFormat.setMaximumFractionDigits(2);
             fiatFormat.setMinimumFractionDigits(2);
+            DecimalFormatSymbols symbolsF = fiatFormat.getDecimalFormatSymbols();
+            symbolsF.setGroupingSeparator(' ');
+            fiatFormat.setDecimalFormatSymbols(symbolsF);
 
-            btcFormat = NumberFormat.getInstance(Locale.getDefault());
+            btcFormat = (DecimalFormat)NumberFormat.getInstance(Locale.getDefault());
             btcFormat.setMaximumFractionDigits(8);
             btcFormat.setMinimumFractionDigits(1);
+            DecimalFormatSymbols symbolsB = btcFormat.getDecimalFormatSymbols();
+            symbolsB.setGroupingSeparator(' ');
+            btcFormat.setDecimalFormatSymbols(symbolsB);
 
             instance = new MonetaryUtil();
         }
@@ -49,19 +56,7 @@ public class MonetaryUtil {
 
         context = ctx;
 
-        if (instance == null) {
-            fiatFormat = NumberFormat.getInstance(Locale.getDefault());
-            fiatFormat.setMaximumFractionDigits(2);
-            fiatFormat.setMinimumFractionDigits(2);
-
-            btcFormat = NumberFormat.getInstance(Locale.getDefault());
-            btcFormat.setMaximumFractionDigits(8);
-            btcFormat.setMinimumFractionDigits(1);
-
-            instance = new MonetaryUtil();
-        }
-
-        return instance;
+        return getInstance();
     }
 
     public NumberFormat getBTCFormat() {


### PR DESCRIPTION
Removed force to US locale - This forced app to expect “.” as separator but devices keypad might only allow user to input “,”.
Custom keypad for samsung devices will now enter correct decimal separator.
TextWatcher will now detect separator of input text.
Decimal grouping symbol set to ‘ ‘ for easy readability.