### PR TITLE
Default account should only be selected onCreate, not onResume.

### DIFF
--- a/app/src/main/java/info/blockchain/wallet/SendFragment.java
+++ b/app/src/main/java/info/blockchain/wallet/SendFragment.java
@@ -221,6 +221,8 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
 
         sendFromSpinner.setSelection(0);
 
+        selectDefaultAccount();
+
         return rootView;
     }
 
@@ -979,8 +981,6 @@ public class SendFragment extends Fragment implements View.OnClickListener, Cust
             if (getArguments().getBoolean("incoming_from_scan", false)) {
                 ;
             }
-
-        selectDefaultAccount();
 
         IntentFilter filter = new IntentFilter(BalanceFragment.ACTION_INTENT);
         LocalBroadcastManager.getInstance(getActivity()).registerReceiver(receiver, filter);


### PR DESCRIPTION
- After scanning private key for watch-only spend confirmation, selectDefaultAccount() was called after returning from qr scan activity, which updated the coin selection just before transaction signing needed to happen.