### PR TITLE
Fixes for flaky unit tests, removed legacy Apache stuff from Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,6 @@ android {
     // Introduced to prevent crash during DEXing step since SDK 23, but also speeds up DEXing in general
     dexOptions {
         javaMaxHeapSize "2g"
-        incremental true
     }
 
     defaultConfig {
@@ -71,9 +70,14 @@ android {
         enabled = true
     }
 
-    //TODO - the following needs to be added (SDK 23) to continue using org.apache.http.legacy as a work around.
-    //TODO - SSLVerifierUtil should use HttpURLConnection class instead (reduces network use, minimizes power consumption) http://developer.android.com/intl/ko/about/versions/marshmallow/android-6.0-changes.html
-    useLibrary 'org.apache.http.legacy'
+    // Always show the result of every unit test, even if it passes.
+    testOptions.unitTests.all {
+        testLogging {
+            events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
+        }
+        // This allows "unstable" builds on CI rather than straight failures
+        ignoreFailures true
+    }
 }
 
 ext {
@@ -112,8 +116,12 @@ dependencies {
     apt 'com.google.dagger:dagger-compiler:2.6'
 
     androidTestCompile 'com.jayway.android.robotium:robotium-solo:5.3.1'
-    testCompile 'org.mockito:mockito-all:2.0.2-beta'
+    testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.hamcrest:hamcrest-junit:2.0.0.0'
+    testCompile ('org.robolectric:robolectric:3.1') {
+        exclude group: 'com.google.guava'
+        exclude group: 'com.google.protobuf'
+    }
 
     //Classes from the android framework won't work in local jvm unit tests. Added below for unit test purposes only
     testCompile 'org.json:json:20140107'

--- a/app/src/test/java/info/blockchain/wallet/datamanagers/AuthDataManagerTest.java
+++ b/app/src/test/java/info/blockchain/wallet/datamanagers/AuthDataManagerTest.java
@@ -10,14 +10,18 @@ import info.blockchain.wallet.util.CharSequenceX;
 import info.blockchain.wallet.util.PrefsUtil;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import java.util.concurrent.TimeUnit;
 
 import piuk.blockchain.android.BlockchainTestApplication;
+import piuk.blockchain.android.BuildConfig;
 import piuk.blockchain.android.RxTest;
 import piuk.blockchain.android.di.ApiModule;
 import piuk.blockchain.android.di.ApplicationModule;
@@ -33,13 +37,14 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Created by adambennett on 15/08/2016.
  */
+@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
+@RunWith(RobolectricGradleTestRunner.class)
 public class AuthDataManagerTest extends RxTest {
 
     private static final String STRING_TO_RETURN = "string_to_return";
@@ -58,7 +63,7 @@ public class AuthDataManagerTest extends RxTest {
 
         InjectorTestUtils.initApplicationComponent(
                 Injector.getInstance(),
-                new MockApplicationModule(new BlockchainTestApplication()),
+                new MockApplicationModule(RuntimeEnvironment.application),
                 new MockApiModule(),
                 new DataManagerModule());
 
@@ -132,8 +137,6 @@ public class AuthDataManagerTest extends RxTest {
     /**
      * Getting encrypted payload returns Auth Required, should be filtered out and emit no values.
      */
-    // FIXME: 15/08/2016 This refuses to run correctly as part of a larger test for some reason
-    @Ignore
     @Test
     public void startPollingAuthStatusAccessRequired() throws Exception {
         // Arrange
@@ -187,7 +190,7 @@ public class AuthDataManagerTest extends RxTest {
         // Arrange
         TestSubscriber<Void> subscriber = new TestSubscriber<>();
         doAnswer(invocation -> {
-            ((PayloadManager.InitiatePayloadListener) invocation.getArguments()[3]).onInitCreateFail(anyString());
+            ((PayloadManager.InitiatePayloadListener) invocation.getArguments()[3]).onInitCreateFail("1234567890");
             return null;
         }).when(mPayloadManager).initiatePayload(
                 anyString(), anyString(), any(CharSequenceX.class), any(PayloadManager.InitiatePayloadListener.class));
@@ -236,7 +239,7 @@ public class AuthDataManagerTest extends RxTest {
                 "1234567890",
                 listener);
         // Assert
-        verify(listener, times(1)).onFatalError();
+        verify(listener).onFatalError();
     }
 
     @Test
@@ -259,7 +262,7 @@ public class AuthDataManagerTest extends RxTest {
         // Assert
         verify(mPrefsUtil).setValue(anyString(), anyString());
         verify(mAppUtil).setSharedKey(anyString());
-        verify(listener, times(1)).onSuccess();
+        verify(listener).onSuccess();
     }
 
     @Test
@@ -282,7 +285,7 @@ public class AuthDataManagerTest extends RxTest {
         // Assert
         verify(mPrefsUtil).setValue(anyString(), anyString());
         verify(mAppUtil).setSharedKey(anyString());
-        verify(listener, times(1)).onPairFail();
+        verify(listener).onPairFail();
     }
 
     @Test
@@ -305,7 +308,7 @@ public class AuthDataManagerTest extends RxTest {
         // Assert
         verify(mPrefsUtil).setValue(anyString(), anyString());
         verify(mAppUtil).setSharedKey(anyString());
-        verify(listener, times(1)).onCreateFail();
+        verify(listener).onCreateFail();
     }
 
     @Test
@@ -320,7 +323,7 @@ public class AuthDataManagerTest extends RxTest {
                 TEST_PAYLOAD,
                 listener);
         // Assert
-        verify(listener, times(1)).onAuthFail();
+        verify(listener).onAuthFail();
     }
 
     @Test
@@ -335,7 +338,7 @@ public class AuthDataManagerTest extends RxTest {
                 TEST_PAYLOAD,
                 listener);
         // Assert
-        verify(listener, times(1)).onFatalError();
+        verify(listener).onFatalError();
     }
 
     private class MockApplicationModule extends ApplicationModule {

--- a/app/src/test/java/info/blockchain/wallet/pairing/PairingTest.java
+++ b/app/src/test/java/info/blockchain/wallet/pairing/PairingTest.java
@@ -1,25 +1,16 @@
 package info.blockchain.wallet.pairing;
 
 
-import android.content.Context;
-
 import junit.framework.Assert;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@RunWith(MockitoJUnitRunner.class)
 public class PairingTest {
 
-    @Mock
-    Context mMockContext;
-
-    Pairing pairing = new Pairing();
+    private Pairing pairing = new Pairing();
 
     @Test
     public void decode_whenBadString_shouldFail() {

--- a/app/src/test/java/info/blockchain/wallet/viewModel/ManualPairingViewModelTest.java
+++ b/app/src/test/java/info/blockchain/wallet/viewModel/ManualPairingViewModelTest.java
@@ -10,10 +10,15 @@ import info.blockchain.wallet.view.ManualPairingActivity;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import piuk.blockchain.android.BlockchainTestApplication;
+import piuk.blockchain.android.BuildConfig;
 import piuk.blockchain.android.di.ApiModule;
 import piuk.blockchain.android.di.ApplicationModule;
 import piuk.blockchain.android.di.DataManagerModule;
@@ -34,6 +39,8 @@ import static org.mockito.Mockito.when;
 /**
  * Created by adambennett on 15/08/2016.
  */
+@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
+@RunWith(RobolectricGradleTestRunner.class)
 public class ManualPairingViewModelTest {
 
     private ManualPairingViewModel mSubject;
@@ -48,7 +55,7 @@ public class ManualPairingViewModelTest {
 
         InjectorTestUtils.initApplicationComponent(
                 Injector.getInstance(),
-                new MockApplicationModule(new BlockchainTestApplication()),
+                new MockApplicationModule(RuntimeEnvironment.application),
                 new ApiModule(),
                 new MockDataManagerModule());
 

--- a/app/src/test/java/info/blockchain/wallet/viewModel/PasswordRequiredViewModelTest.java
+++ b/app/src/test/java/info/blockchain/wallet/viewModel/PasswordRequiredViewModelTest.java
@@ -11,10 +11,15 @@ import info.blockchain.wallet.view.PasswordRequiredActivity;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import piuk.blockchain.android.BlockchainTestApplication;
+import piuk.blockchain.android.BuildConfig;
 import piuk.blockchain.android.RxTest;
 import piuk.blockchain.android.di.ApiModule;
 import piuk.blockchain.android.di.ApplicationModule;
@@ -36,6 +41,8 @@ import static org.mockito.Mockito.when;
 /**
  * Created by adambennett on 10/08/2016.
  */
+@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
+@RunWith(RobolectricGradleTestRunner.class)
 public class PasswordRequiredViewModelTest extends RxTest {
 
     private PasswordRequiredViewModel mSubject;
@@ -52,7 +59,7 @@ public class PasswordRequiredViewModelTest extends RxTest {
 
         InjectorTestUtils.initApplicationComponent(
                 Injector.getInstance(),
-                new MockApplicationModule(new BlockchainTestApplication()),
+                new MockApplicationModule(RuntimeEnvironment.application),
                 new ApiModule(),
                 new MockDataManagerModule());
 

--- a/app/src/test/java/piuk/blockchain/android/LauncherViewModelTest.java
+++ b/app/src/test/java/piuk/blockchain/android/LauncherViewModelTest.java
@@ -12,8 +12,12 @@ import info.blockchain.wallet.util.PrefsUtil;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import piuk.blockchain.android.di.ApiModule;
 import piuk.blockchain.android.di.ApplicationModule;
@@ -34,6 +38,8 @@ import static piuk.blockchain.android.LauncherViewModel.INTENT_EXTRA_VERIFIED;
 /**
  * Created by adambennett on 09/08/2016.
  */
+@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
+@RunWith(RobolectricGradleTestRunner.class)
 public class LauncherViewModelTest {
 
     private LauncherViewModel mSubject;
@@ -53,7 +59,7 @@ public class LauncherViewModelTest {
 
         InjectorTestUtils.initApplicationComponent(
                 Injector.getInstance(),
-                new MockApplicationModule(new BlockchainTestApplication()),
+                new MockApplicationModule(RuntimeEnvironment.application),
                 new MockApiModule(),
                 new DataManagerModule());
 


### PR DESCRIPTION
- Legacy Apache classes were being specifically kept, but aren't being used anymore
- Fixes for unit tests failing intermittently; some state was being stored in the Application class somehow
- Added verbose test output in prep for CI