### PR TITLE
Fix for ActionBar bug

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/base/BaseAuthActivity.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/base/BaseAuthActivity.java
@@ -21,6 +21,7 @@ import piuk.blockchain.android.BuildConfig;
 import piuk.blockchain.android.R;
 import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.rxjava.RxUtil;
+import piuk.blockchain.android.util.AndroidUtils;
 import piuk.blockchain.android.util.ApplicationLifeCycle;
 import piuk.blockchain.android.util.SSLVerifyUtil;
 
@@ -79,9 +80,12 @@ public class BaseAuthActivity extends AppCompatActivity {
      * @param title   The title for the page, as a StringRes
      */
     public void setupToolbar(Toolbar toolbar, @StringRes int title) {
-        toolbar.setTitle(CalligraphyUtils.applyTypefaceSpan(
-                getString(title),
-                TypefaceUtils.load(getAssets(), "fonts/Montserrat-Regular.ttf")));
+        // Fix for bug with formatted ActionBars https://android-review.googlesource.com/#/c/47831/
+        if (AndroidUtils.is18orHigher()) {
+            toolbar.setTitle(CalligraphyUtils.applyTypefaceSpan(
+                    getString(title),
+                    TypefaceUtils.load(getAssets(), "fonts/Montserrat-Regular.ttf")));
+        }
 
         setSupportActionBar(toolbar);
     }
@@ -95,9 +99,12 @@ public class BaseAuthActivity extends AppCompatActivity {
      * @param title     The title for the page, as a StringRes
      */
     public void setupToolbar(ActionBar actionBar, @StringRes int title) {
-        actionBar.setTitle(CalligraphyUtils.applyTypefaceSpan(
-                getString(title),
-                TypefaceUtils.load(getAssets(), "fonts/Montserrat-Regular.ttf")));
+        // Fix for bug with formatted ActionBars https://android-review.googlesource.com/#/c/47831/
+        if (AndroidUtils.is18orHigher()) {
+            actionBar.setTitle(CalligraphyUtils.applyTypefaceSpan(
+                    getString(title),
+                    TypefaceUtils.load(getAssets(), "fonts/Montserrat-Regular.ttf")));
+        }
     }
 
     @CallSuper

--- a/app/src/main/java/piuk/blockchain/android/util/AndroidUtils.java
+++ b/app/src/main/java/piuk/blockchain/android/util/AndroidUtils.java
@@ -8,6 +8,10 @@ public class AndroidUtils {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN;
     }
 
+    public static boolean is18orHigher() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+    }
+
     public static boolean is21orHigher() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
     }
@@ -23,4 +27,5 @@ public class AndroidUtils {
     public static boolean is25orHigher() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1;
     }
+
 }


### PR DESCRIPTION
Fix issue where pressing the back button in the ActionBar on API 15, 16 & 17 would throw an IllegalArgumentException. If setting custom fonts in Android, any MenuItem selected events log the value of the ActionBar title, which doesn’t handle custom fonts (applied via Spannable) on the affected versions and crashes instead.

See here for more info: https://android-review.googlesource.com/#/c/47831/