### PR TITLE
Feature/balance caching

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/balance/BalanceFragment.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/balance/BalanceFragment.java
@@ -132,7 +132,8 @@ public class BalanceFragment extends Fragment implements BalanceViewModel.DataLi
     }
 
     private void setAccountSpinner() {
-        ((AppCompatActivity) getContext()).setSupportActionBar((Toolbar) getActivity().findViewById(R.id.toolbar_general));
+        ((AppCompatActivity) getContext()).setSupportActionBar(
+                (Toolbar) getActivity().findViewById(R.id.toolbar_general));
 
         if (viewModel.getActiveAccountAndAddressList().size() > 1) {
             accountSpinner.setVisibility(View.VISIBLE);
@@ -155,7 +156,7 @@ public class BalanceFragment extends Fragment implements BalanceViewModel.DataLi
         LocalBroadcastManager.getInstance(getContext()).registerReceiver(receiver, filter);
 
         viewModel.updateAccountList();
-        viewModel.refreshFacilitatedTransactions();
+        viewModel.getFacilitatedTransactions();
         viewModel.updateBalanceAndTransactionList(accountSpinner.getSelectedItemPosition(), isBTC, true);
 
         binding.rvTransactions.clearOnScrollListeners();

--- a/app/src/main/java/piuk/blockchain/android/ui/balance/BalanceViewModel.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/balance/BalanceViewModel.java
@@ -435,9 +435,6 @@ public class BalanceViewModel extends BaseViewModel {
         }
     }
 
-    /**
-     * Cached transactions. To be called sometime in the future
-     */
     void getFacilitatedTransactions() {
         compositeDisposable.add(
                 contactsDataManager.getFacilitatedTransactions()

--- a/app/src/main/java/piuk/blockchain/android/ui/base/BaseAuthActivity.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/base/BaseAuthActivity.java
@@ -113,10 +113,22 @@ public class BaseAuthActivity extends AppCompatActivity {
      * @param title     The title for the page, as a StringRes
      */
     public void setupToolbar(ActionBar actionBar, @StringRes int title) {
+        setupToolbar(actionBar, getString(title));
+    }
+
+    /**
+     * Applies the title to the Activity's {@link ActionBar}. This method is the fragment equivalent
+     * of {@link #setupToolbar(Toolbar, int)} Also applies the Montserrat-Regular font, as this
+     * cannot be done elsewhere for now.
+     *
+     * @param actionBar The {@link ActionBar} for the current activity
+     * @param title     The title for the page, as a String
+     */
+    public void setupToolbar(ActionBar actionBar, String title) {
         // Fix for bug with formatted ActionBars https://android-review.googlesource.com/#/c/47831/
         if (AndroidUtils.is18orHigher()) {
             actionBar.setTitle(CalligraphyUtils.applyTypefaceSpan(
-                    getString(title),
+                    title,
                     TypefaceUtils.load(getAssets(), "fonts/Montserrat-Regular.ttf")));
         } else {
             actionBar.setTitle(title);

--- a/app/src/main/java/piuk/blockchain/android/ui/home/MainActivity.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/home/MainActivity.java
@@ -113,6 +113,7 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
     private boolean paymentToContactMade = false;
     private Typeface typeface;
     private WebView buyWebView;
+    private BalanceFragment balanceFragment;
 
     private BroadcastReceiver receiver = new BroadcastReceiver() {
         @Override
@@ -143,7 +144,7 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
 
         appUtil = new AppUtil(this);
         viewModel = new MainViewModel(this);
-        viewModel.onViewReady();
+        balanceFragment = BalanceFragment.newInstance(false);
 
         binding.drawerLayout.addDrawerListener(new DrawerLayout.DrawerListener() {
             @Override
@@ -173,6 +174,9 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
         toolbar.setTitle("");
         setSupportActionBar(toolbar);
         ViewUtils.setElevation(toolbar, 0F);
+
+        // Notify ViewModel that page is setup
+        viewModel.onViewReady();
 
         // Create items
         AHBottomNavigationItem item1 = new AHBottomNavigationItem(R.string.send_bitcoin, R.drawable.vector_send, R.color.white);
@@ -365,7 +369,8 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
         startSendFragment(strResult, scanRoute);
     }
 
-    private Intent putWebViewState(Intent intent) {
+    @Thunk
+    Intent putWebViewState(Intent intent) {
         Bundle state = new Bundle();
         buyWebView.saveState(state);
         return intent.putExtra(WEB_VIEW_STATE_KEY, state);
@@ -673,8 +678,11 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
 
     @Override
     public void onStartBalanceFragment(boolean paymentToContactMade) {
-        BalanceFragment fragment = BalanceFragment.newInstance(paymentToContactMade);
-        replaceFragmentWithAnimation(fragment);
+        if (paymentToContactMade) {
+            balanceFragment = BalanceFragment.newInstance(true);
+        }
+        replaceFragmentWithAnimation(balanceFragment);
+        toolbar.setTitle("");
         viewModel.checkIfShouldShowSurvey();
     }
 
@@ -784,12 +792,12 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
 
     private void startSendFragment(@Nullable String scanData, String scanRoute) {
         SendFragment sendFragment = SendFragment.newInstance(scanData, scanRoute, getSelectedAccountFromFragments());
-        replaceFragmentWithAnimation(sendFragment);
+        addFragmentToBackStack(sendFragment);
     }
 
     private void startReceiveFragment() {
         ReceiveFragment receiveFragment = ReceiveFragment.newInstance(getSelectedAccountFromFragments());
-        replaceFragmentWithAnimation(receiveFragment);
+        addFragmentToBackStack(receiveFragment);
     }
 
     private int getSelectedAccountFromFragments() {
@@ -809,6 +817,14 @@ public class MainActivity extends BaseAuthActivity implements BalanceFragment.On
         FragmentTransaction transaction = fragmentManager.beginTransaction();
         transaction.setCustomAnimations(R.anim.fade_in, R.anim.fade_out)
                 .replace(R.id.content_frame, fragment)
+                .commitAllowingStateLoss();
+    }
+
+    private void addFragmentToBackStack(Fragment fragment) {
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        fragmentManager.beginTransaction()
+                .addToBackStack(fragment.getClass().getName())
+                .add(R.id.content_frame, fragment)
                 .commitAllowingStateLoss();
     }
 

--- a/app/src/main/java/piuk/blockchain/android/ui/upgrade/UpgradeWalletActivity.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/upgrade/UpgradeWalletActivity.java
@@ -58,6 +58,8 @@ public class UpgradeWalletActivity extends BaseAuthActivity implements
         binding.pager.addOnPageChangeListener(this);
 
         binding.upgradeBtn.setOnClickListener(v -> upgradeClicked());
+
+        viewModel.onViewReady();
     }
 
     @Override

--- a/app/src/main/res/layout/fragment_send.xml
+++ b/app/src/main/res/layout/fragment_send.xml
@@ -5,6 +5,7 @@
         android:id="@+id/main_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:background="@color/white"
         android:focusable="true"
         android:focusableInTouchMode="true">
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     ext {
         supportVersion = '25.3.1'
         googleServicesVersion = '10.2.1'
-        rxJavaVersion = '2.0.8'
+        rxJavaVersion = '2.0.9'
         rxAndroidVersion = '2.0.1'
         daggerVersion = '2.10'
         retrofitVersion = '2.2.0'


### PR DESCRIPTION
Caching the balance fragment fixes issue of the whole page reloading each time you switch tabs. Previously a new fragment was being instantiated and the whole view had to be redrawn, so even if you cached transactions it would take a second to setup.