### PR TITLE
fix(Send): Invalidate receiving address after user edits field.

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/send/SendFragment.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/send/SendFragment.java
@@ -29,6 +29,7 @@ import android.text.InputType;
 import android.text.TextWatcher;
 import android.text.method.DigitsKeyListener;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -39,6 +40,7 @@ import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.EditText;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jakewharton.rxbinding2.widget.RxTextView;
@@ -460,6 +462,25 @@ public class SendFragment extends Fragment implements SendContract.DataListener,
             v.performClick();
             return false;
         });
+        binding.destination.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+                //no op
+            }
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                //no op
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {
+                //TextChanged listener required to invalidate receive address in memory when user
+                //chooses to edit address populated via QR
+                viewModel.setReceivingAddress(null);
+            }
+        });
+
         binding.destination.setOnFocusChangeListener((v, hasFocus) -> {
             if (hasFocus && customKeypad != null) {
                 customKeypad.setNumpadVisibility(View.GONE);

--- a/app/src/main/java/piuk/blockchain/android/ui/send/SendFragment.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/send/SendFragment.java
@@ -63,6 +63,7 @@ import piuk.blockchain.android.R;
 import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.connectivity.ConnectivityStatus;
 import piuk.blockchain.android.data.contacts.PaymentRequestType;
+import piuk.blockchain.android.data.rxjava.IgnorableDefaultObserver;
 import piuk.blockchain.android.data.services.EventService;
 import piuk.blockchain.android.databinding.AlertWatchOnlySpendBinding;
 import piuk.blockchain.android.databinding.FragmentSendBinding;
@@ -462,24 +463,12 @@ public class SendFragment extends Fragment implements SendContract.DataListener,
             v.performClick();
             return false;
         });
-        binding.destination.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                //no op
-            }
 
-            @Override
-            public void onTextChanged(CharSequence s, int start, int before, int count) {
-                //no op
-            }
-
-            @Override
-            public void afterTextChanged(Editable s) {
-                //TextChanged listener required to invalidate receive address in memory when user
-                //chooses to edit address populated via QR
-                viewModel.setReceivingAddress(null);
-            }
-        });
+        //TextChanged listener required to invalidate receive address in memory when user
+        //chooses to edit address populated via QR
+        RxTextView.textChanges(binding.destination)
+                .doOnNext(ignored -> viewModel.setReceivingAddress(null))
+                .subscribe(new IgnorableDefaultObserver<>());
 
         binding.destination.setOnFocusChangeListener((v, hasFocus) -> {
             if (hasFocus && customKeypad != null) {


### PR DESCRIPTION
Added a on text change listener to invalidate receive address kept in memory after scanning a receive address. Some devices ignore the on click listener that was put in place to prevent this behaviour.