### PR TITLE
chore(Crashlytics): Remove Firebase crash reporting for Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ local.properties
 # QA
 *credentials_qa.xml
 
-# Migration to Android Studio 2.4 Preview
+# Migration to Android Studio 3.0 Preview
 projectFilesBackup/
 
 # Captures
@@ -30,3 +30,6 @@ google-services.json
 
 # Environment URLs
 urls.properties
+
+# Fabric API Key
+fabric.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'io.fabric'
 apply plugin: 'me.tatarka.retrolambda'
 apply plugin: 'kotlin-android'
 apply from: 'environment.gradle'
@@ -43,11 +44,13 @@ android {
             resValue "string", "google_maps_key", "AIzaSyB_5WN2exwvF4pqQ6rW6JdkHcYWjZOim4w"
             multiDexEnabled false
             buildConfigField "boolean", "DOGFOOD", "false"
+            buildConfigField "boolean", "USE_CRASHLYTICS", "true"
         }
         debug {
             resValue "string", "google_maps_key", "AIzaSyDOrXqr30C3vjiUM4HMeZO8HFpTIH8CVaM"
             multiDexEnabled true
             buildConfigField "boolean", "DOGFOOD", "false"
+            buildConfigField "boolean", "USE_CRASHLYTICS", "false"
         }
         dogfood {
             signingConfig signingConfigs.debug
@@ -61,6 +64,7 @@ android {
             resValue "string", "google_maps_key", "AIzaSyB_5WN2exwvF4pqQ6rW6JdkHcYWjZOim4w"
             multiDexEnabled false
             buildConfigField "boolean", "DOGFOOD", "true"
+            buildConfigField "boolean", "USE_CRASHLYTICS", "true"
         }
     }
     productFlavors {
@@ -127,8 +131,6 @@ dependencies {
     compile "com.android.support:support-v13:$supportVersion"
     compile "com.android.support:preference-v7:$supportVersion"
     compile "com.android.support:preference-v14:$supportVersion"
-    // Enable crash reporting only for release version
-    releaseCompile "com.google.firebase:firebase-crash:$googleServicesVersion"
     compile "com.google.firebase:firebase-messaging:$googleServicesVersion"
     compile "com.google.android.gms:play-services-maps:$googleServicesVersion"
     compile 'org.bitcoinj:bitcoinj-core:0.14.4'
@@ -166,6 +168,10 @@ dependencies {
     devCompile 'org.slf4j:slf4j-simple:1.7.20'
     // ViewPager Indicator
     compile 'me.relex:circleindicator:1.2.2@aar'
+    // Crash reporting
+    compile('com.crashlytics.sdk.android:crashlytics:2.6.8@aar') {
+        transitive = true
+    }
 
     // UI/Instrumentation Tests
     androidTestCompile 'junit:junit:4.12'
@@ -198,19 +204,20 @@ dependencies {
 buildscript {
     repositories {
         jcenter()
+        maven { url 'https://maven.fabric.io/public' }
     }
 
     dependencies {
         classpath 'me.tatarka:gradle-retrolambda:3.6.1'
+        classpath 'io.fabric.tools:gradle:1.22.1'
     }
 }
 
 // Required for CountryPicker
 repositories {
     jcenter()
-    maven {
-        url "https://jitpack.io"
-    }
+    maven { url "https://jitpack.io" }
+    maven { url 'https://maven.fabric.io/public' }
 }
 
 // This must remain at the bottom of this file until Google work out a better way to do this

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -131,8 +131,8 @@
             android:configChanges="keyboardHidden|orientation|screenSize" />
 
         <activity
-          android:name=".ui.buy.BuyActivity"
-          android:configChanges="keyboardHidden|orientation|screenSize" />
+            android:name=".ui.buy.BuyActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize" />
 
         <service
             android:name=".data.websocket.WebSocketService"
@@ -156,6 +156,10 @@
         <meta-data
             android:name="com.google.firebase.messaging.default_notification_color"
             android:resource="@color/white" />
+
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="697b88bc5b5646cd6ac3aebf86e525ff14c51426" />
 
         <provider
             android:name="android.support.v4.content.FileProvider"

--- a/app/src/main/java/piuk/blockchain/android/BlockchainApplication.java
+++ b/app/src/main/java/piuk/blockchain/android/BlockchainApplication.java
@@ -11,6 +11,8 @@ import android.support.v7.app.AppCompatDelegate;
 import android.support.v7.widget.AppCompatButton;
 import android.util.Log;
 
+import com.crashlytics.android.Crashlytics;
+
 import info.blockchain.wallet.BlockchainFramework;
 import info.blockchain.wallet.FrameworkInterface;
 
@@ -20,6 +22,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import dagger.Lazy;
+import io.fabric.sdk.android.Fabric;
 import io.reactivex.plugins.RxJavaPlugins;
 import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.connectivity.ConnectivityManager;
@@ -76,6 +79,10 @@ public class BlockchainApplication extends Application implements FrameworkInter
     @Override
     public void onCreate() {
         super.onCreate();
+        if (BuildConfig.USE_CRASHLYTICS) {
+            // Init crash reporting
+            Fabric.with(this, new Crashlytics());
+        }
         // Init objects first
         Injector.getInstance().init(this);
         // Inject into Application


### PR DESCRIPTION
Since Google has [acquired the team at Fabric](https://fabric.io/blog/fabric-joins-google/), they have now deprecated the Firebase crash reporting suite that we've been using for a while in favour of Crashlytics, which is soon to be integrated fully into the Firebase panel. Crashlytics is hugely better and more flexible, so this is a welcome development.

If anyone from the team wants access to the crash reporting panel, message myself or Riaan and we can invite you to the project.