### PR TITLE
Refresh magic hash when loading exchange data

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/data/services/ExchangeService.java
+++ b/app/src/main/java/piuk/blockchain/android/data/services/ExchangeService.java
@@ -75,10 +75,14 @@ public class ExchangeService {
                         })
                         .compose(RxUtil.applySchedulersToObservable())
                 ),
-                getExchangeData().map(buyMetadata -> {
-                    byte[] magicHash = buyMetadata.getMagicHash();
-                    return magicHash == null ? "" : Hex.toHexString(magicHash);
-                }),
+                getExchangeData().flatMap(buyMetadata -> Observable
+                        .fromCallable(() -> {
+                            buyMetadata.fetchMagic();
+                            byte[] magicHash = buyMetadata.getMagicHash();
+                            return magicHash == null ? "" : Hex.toHexString(magicHash);
+                        })
+                        .compose(RxUtil.applySchedulersToObservable())
+                ),
                 (externalJson, magicHash) -> {
                     String walletJson = payloadManager.getPayload().toJson();
                     String password = payloadManager.getTempPassword();


### PR DESCRIPTION
_Problem_

After the web wallet saves data to the metadata service, if the web view is closed and reopened, Android will fetch the new metadata, but will not get the new magic hash. Android then passes an incorrect magic has to the web wallet, causing saves to metadata to not work.

_Solution_

Fetch the latest magic hash before passing it to the web wallet.

I'm not sure this is the best way to do this, I think it might be better to fix this in v3-jar. I tried making it so the magic hash will update automatically during calls to Metadata::getMetadata, but couldn't get that to work. Let me know if you have any ideas @ditn @riaanjvos