### PR TITLE
Prevent redirecting to browser when buy is closed

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/buy/BuyActivity.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/buy/BuyActivity.java
@@ -57,8 +57,8 @@ public class BuyActivity extends BaseAuthActivity implements BuyViewModel.DataLi
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        frontendJavascriptManager.teardown();
         binding.webview.removeJavascriptInterface(FrontendJavascriptManager.JS_INTERFACE_NAME);
+        binding.webview.reload();
 
         if (didBuyBitcoin) {
             viewModel.reloadExchangeDate();


### PR DESCRIPTION
This fixes the issue where pressing the "back" button will open blockchain.info in the phone's browser, on some phones. I think what was happening is that the teardown() function was making a redirect, which is sometimes intercepted by Android. Teardown() is really just to refresh the page, this changes it so that the web view is refreshed directly, preventing any redirect.