### PR TITLE
Fix - Buy trades

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/data/exchange/CoinifyData.java
+++ b/app/src/main/java/piuk/blockchain/android/data/exchange/CoinifyData.java
@@ -13,6 +13,9 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CoinifyData implements ExchangeAccount {
+    public CoinifyData() {
+    }
+
     @JsonProperty("user")
     private int user = 0;
 

--- a/app/src/main/java/piuk/blockchain/android/data/exchange/ExchangeData.java
+++ b/app/src/main/java/piuk/blockchain/android/data/exchange/ExchangeData.java
@@ -7,6 +7,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 
 public class ExchangeData {
+    public ExchangeData() {
+    }
+
     @JsonProperty("coinify")
     private CoinifyData coinify = null;
 

--- a/app/src/main/java/piuk/blockchain/android/data/exchange/SfoxData.java
+++ b/app/src/main/java/piuk/blockchain/android/data/exchange/SfoxData.java
@@ -14,6 +14,9 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SfoxData implements ExchangeAccount {
+    public SfoxData() {
+    }
+
     @JsonProperty("user")
     private String user = null;
 

--- a/app/src/main/java/piuk/blockchain/android/data/exchange/TradeData.java
+++ b/app/src/main/java/piuk/blockchain/android/data/exchange/TradeData.java
@@ -11,6 +11,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TradeData {
+    public TradeData() {
+    }
+
     @JsonProperty("id")
     private int id = 0;
 

--- a/app/src/main/java/piuk/blockchain/android/data/services/ExchangeService.java
+++ b/app/src/main/java/piuk/blockchain/android/data/services/ExchangeService.java
@@ -132,7 +132,7 @@ public class ExchangeService {
 
                     return trades;
                 })
-                .filter(tradeData -> !tradeData.isConfirmed())
+                .filter(tradeData -> tradeData.isBuy() && !tradeData.isConfirmed())
                 .map(tradeData ->
                         payloadDataManager.getReceiveAddressAtArbitraryPosition(
                                 payloadDataManager.getAccount(tradeData.getAccountIndex()),


### PR DESCRIPTION
There was an issue with mapping exchange data JSON to java objects. I couldn't reproduce on any of the phones I tried, but from what I've read it seems like the issue could be missing default constructors. Would that make sense? Error message in the ticket contains:

```java
06-14 13:51:26.216 8012-8012/? W/System.err: com.fasterxml.jackson.databind.JsonMappingException: No suitable constructor found for type [simple type, class piuk.blockchain.android.data.exchange.CoinifyData]: can not instantiate from JSON object (missing default constructor or creator, or perhaps need to add/enable type information?)
```

I'm also filtering out sell trades now, since those don't need to be watched.