### PR TITLE
Feature/timber

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -207,6 +207,7 @@ dependencies {
     // Custom fonts
     compile 'uk.co.chrisjenx:calligraphy:2.2.0'
     // Logging
+    compile 'com.jakewharton.timber:timber:4.5.1'
     releaseCompile 'org.slf4j:slf4j-nop:1.7.20'
     dogfoodCompile 'org.slf4j:slf4j-nop:1.7.20'
     debugCompile 'org.slf4j:slf4j-simple:1.7.20'

--- a/app/src/main/java/piuk/blockchain/android/BlockchainApplication.java
+++ b/app/src/main/java/piuk/blockchain/android/BlockchainApplication.java
@@ -39,6 +39,7 @@ import piuk.blockchain.android.util.PrefsUtil;
 import piuk.blockchain.android.util.annotations.Thunk;
 import piuk.blockchain.android.util.exceptions.LoggingExceptionHandler;
 import retrofit2.Retrofit;
+import timber.log.Timber;
 
 /**
  * Created by adambennett on 04/08/2016.
@@ -87,6 +88,10 @@ public class BlockchainApplication extends Application implements FrameworkInter
         if (BuildConfig.USE_CRASHLYTICS) {
             // Init crash reporting
             Fabric.with(this, new Crashlytics());
+        }
+        // Init Timber
+        if (BuildConfig.DEBUG) {
+            Timber.plant(new Timber.DebugTree());
         }
         // Init objects first
         Injector.getInstance().init(this);

--- a/app/src/main/java/piuk/blockchain/android/data/access/AccessState.java
+++ b/app/src/main/java/piuk/blockchain/android/data/access/AccessState.java
@@ -16,9 +16,9 @@ import piuk.blockchain.android.util.PrefsUtil;
 public class AccessState {
 
     public static final String LOGOUT_ACTION = "info.blockchain.wallet.LOGOUT";
-    public static final int SHOW_BTC = 1;
-    public static final int SHOW_FIAT = 2;
 
+    private static final int SHOW_BTC = 1;
+    private static final int SHOW_FIAT = 2;
     private static final long LOGOUT_TIMEOUT_MILLIS = 1000L * 30L;
 
     private static AccessState instance;

--- a/app/src/main/java/piuk/blockchain/android/data/datamanagers/TransactionListDataManager.java
+++ b/app/src/main/java/piuk/blockchain/android/data/datamanagers/TransactionListDataManager.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import io.reactivex.Observable;
+import io.reactivex.Single;
 import piuk.blockchain.android.data.rxjava.RxBus;
 import piuk.blockchain.android.data.rxjava.RxUtil;
 import piuk.blockchain.android.data.stores.TransactionListStore;
@@ -111,21 +112,10 @@ public class TransactionListDataManager {
      * @return An Observable object wrapping a Tx. Will call onError if not found with a
      * NullPointerException
      */
-    public Observable<TransactionSummary> getTxFromHash(String transactionHash) {
-        return Observable.create(emitter -> {
-            //noinspection Convert2streamapi
-            for (TransactionSummary tx : getTransactionList()) {
-                if (tx.getHash().equals(transactionHash)) {
-                    if (!emitter.isDisposed()) {
-                        emitter.onNext(tx);
-                        emitter.onComplete();
-                    }
-                    return;
-                }
-            }
-
-            if (!emitter.isDisposed()) emitter.onError(new NullPointerException("Tx not found"));
-        });
+    public Single<TransactionSummary> getTxFromHash(String transactionHash) {
+        return Observable.fromIterable(getTransactionList())
+                .filter(tx -> tx.getHash().equals(transactionHash))
+                .firstOrError();
     }
 
     /**

--- a/app/src/main/java/piuk/blockchain/android/data/notifications/NotificationTokenManager.java
+++ b/app/src/main/java/piuk/blockchain/android/data/notifications/NotificationTokenManager.java
@@ -4,7 +4,6 @@ import com.google.firebase.iid.FirebaseInstanceId;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import info.blockchain.wallet.payload.PayloadManager;
 import info.blockchain.wallet.payload.data.Wallet;
@@ -17,10 +16,9 @@ import piuk.blockchain.android.data.rxjava.RxBus;
 import piuk.blockchain.android.data.rxjava.RxUtil;
 import piuk.blockchain.android.data.services.NotificationService;
 import piuk.blockchain.android.util.PrefsUtil;
+import timber.log.Timber;
 
 public class NotificationTokenManager {
-
-    private static final String TAG = NotificationTokenManager.class.getSimpleName();
 
     private NotificationService notificationService;
     private AccessState accessState;
@@ -79,6 +77,7 @@ public class NotificationTokenManager {
     }
 
     // TODO: 16/01/2017 Call me on logout?
+
     /**
      * Resets Instance ID and revokes all tokens. Clears stored token if successful
      */
@@ -109,7 +108,7 @@ public class NotificationTokenManager {
         // TODO: 09/11/2016 Decide what to do if sending fails, perhaps retry?
         notificationService.sendNotificationToken(refreshedToken, guid, sharedKey)
                 .subscribeOn(Schedulers.io())
-                .subscribe(() -> Log.d(TAG, "sendFirebaseToken: success"), Throwable::printStackTrace);
+                .subscribe(() -> Timber.d("sendFirebaseToken: success"), Throwable::printStackTrace);
     }
 
     /**

--- a/app/src/main/java/piuk/blockchain/android/data/rxjava/RxBus.java
+++ b/app/src/main/java/piuk/blockchain/android/data/rxjava/RxBus.java
@@ -2,7 +2,6 @@ package piuk.blockchain.android.data.rxjava;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -11,6 +10,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
 import io.reactivex.subjects.Subject;
+import timber.log.Timber;
 
 /**
  * A class that allows callers to register {@link PublishSubject} objects by passing in the class
@@ -18,8 +18,6 @@ import io.reactivex.subjects.Subject;
  * Dagger2.
  */
 public class RxBus {
-
-    private static final String TAG = RxBus.class.getSimpleName();
 
     /**
      * A threadsafe map of lists of {@link PublishSubject} objects, where their type is used as the
@@ -73,7 +71,7 @@ public class RxBus {
                 subjectsMap.remove(type);
             }
         } else {
-            Log.e(TAG, "unregister of type " + type.getSimpleName() + " failed, as no PublishSubject with a matching type was found");
+            Timber.e("unregister of type " + type.getSimpleName() + " failed, as no PublishSubject with a matching type was found");
         }
     }
 
@@ -93,7 +91,7 @@ public class RxBus {
                 subject.onNext(content);
             }
         } else {
-            Log.i(TAG, "emitEvent of type " + type.getSimpleName() + " failed, as no PublishSubject was registered");
+            Timber.i("emitEvent of type " + type.getSimpleName() + " failed, as no PublishSubject was registered");
         }
     }
 }

--- a/app/src/main/java/piuk/blockchain/android/data/rxjava/RxUtil.java
+++ b/app/src/main/java/piuk/blockchain/android/data/rxjava/RxUtil.java
@@ -10,10 +10,9 @@ import io.reactivex.disposables.CompositeDisposable;
 import io.reactivex.functions.Function;
 import io.reactivex.schedulers.Schedulers;
 import piuk.blockchain.android.ui.base.BasePresenter;
+import timber.log.Timber;
 
 /**
- * Created by adambennett on 12/08/2016.
- *
  * A class for basic RxJava utilities, ie Transformer classes
  */
 
@@ -26,7 +25,7 @@ public final class RxUtil {
     public static <T> ObservableTransformer<T, T> applySchedulersToObservable() {
         return observable -> observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .doOnError(Throwable::printStackTrace);
+                .doOnError(Timber::e);
     }
 
     /**
@@ -36,7 +35,7 @@ public final class RxUtil {
     public static <T> SingleTransformer<T, T> applySchedulersToSingle() {
         return observable -> observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .doOnError(Throwable::printStackTrace);
+                .doOnError(Timber::e);
     }
 
     /**
@@ -46,7 +45,7 @@ public final class RxUtil {
     public static CompletableTransformer applySchedulersToCompletable() {
         return observable -> observable.subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
-                .doOnError(Throwable::printStackTrace);
+                .doOnError(Timber::e);
     }
 
     /**

--- a/app/src/main/java/piuk/blockchain/android/ui/balance/BalancePresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/balance/BalancePresenter.kt
@@ -31,6 +31,7 @@ import piuk.blockchain.android.ui.home.MainActivity
 import piuk.blockchain.android.ui.onboarding.OnboardingPagerContent
 import piuk.blockchain.android.ui.swipetoreceive.SwipeToReceiveHelper
 import piuk.blockchain.android.util.*
+import timber.log.Timber
 import java.text.DecimalFormat
 import java.util.*
 import javax.inject.Inject
@@ -175,6 +176,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                         }
                     }
                 }, {
+                    Timber.e(it)
                     view.showToast(
                             R.string.contacts_not_found_error,
                             ToastCustom.TYPE_ERROR
@@ -204,7 +206,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                                 view.showTransactionCancelDialog(fctxId)
                         }
                     }
-                }, { /* No-op */ })
+                }, { Timber.e(it) })
     }
 
     internal fun onAccountChosen(accountPosition: Int, fctxId: String) {
@@ -279,7 +281,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                     } else {
                         view.startReceiveFragment()
                     }
-                }, { it.printStackTrace() })
+                }, { Timber.e(it) })
     }
 
     internal fun disableAnnouncement() {
@@ -415,7 +417,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                 .compose(RxUtil.addObservableToCompositeDisposable(this))
                 .subscribe(
                         { /* No-op */ },
-                        { throwable -> throwable.printStackTrace() })
+                        { Timber.e(it) })
     }
 
     private fun storeSwipeReceiveAddresses() {
@@ -427,7 +429,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                 .compose(RxUtil.addCompletableToCompositeDisposable(this))
                 .subscribe(
                         { /* No-op */ },
-                        { it.printStackTrace() })
+                        { Timber.e(it) })
     }
 
     private fun subscribeToEvents() {
@@ -485,7 +487,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                 .compose(RxUtil.addObservableToCompositeDisposable(this))
                 .subscribe(
                         { view.onLoadOnboardingPages(getOnboardingPages(it)) },
-                        { it.printStackTrace() })
+                        { Timber.e(it) })
     }
 
     private fun getOnboardingPages(isBuyAllowed: Boolean): List<OnboardingPagerContent> {
@@ -546,7 +548,7 @@ class BalancePresenter : BasePresenter<BalanceView>() {
                     } else {
                         view.onHideAnnouncement()
                     }
-                }, { it.printStackTrace() })
+                }, { Timber.e(it) })
     }
 
     private fun getFormattedPriceString(): String {

--- a/app/src/main/java/piuk/blockchain/android/ui/chooser/AccountChooserViewModel.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/chooser/AccountChooserViewModel.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import piuk.blockchain.android.R;
+import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.contacts.ContactsPredicates;
 import piuk.blockchain.android.data.contacts.PaymentRequestType;
 import piuk.blockchain.android.data.datamanagers.ContactsDataManager;
@@ -19,9 +20,6 @@ import piuk.blockchain.android.ui.base.BaseViewModel;
 import piuk.blockchain.android.ui.receive.WalletAccountHelper;
 import piuk.blockchain.android.util.PrefsUtil;
 import piuk.blockchain.android.util.StringUtils;
-
-import static piuk.blockchain.android.ui.send.SendViewModel.SHOW_BTC;
-import static piuk.blockchain.android.ui.send.SendViewModel.SHOW_FIAT;
 
 
 @SuppressWarnings("WeakerAccess")
@@ -33,9 +31,9 @@ public class AccountChooserViewModel extends BaseViewModel {
     @Inject WalletAccountHelper walletAccountHelper;
     @Inject StringUtils stringUtils;
     @Inject ContactsDataManager contactsDataManager;
+    @Inject AccessState accessState;
 
     private List<ItemAccount> itemAccounts = new ArrayList<>();
-    private boolean isBtc;
 
     interface DataListener {
 
@@ -59,9 +57,6 @@ public class AccountChooserViewModel extends BaseViewModel {
     AccountChooserViewModel(DataListener dataListener) {
         Injector.getInstance().getDataManagerComponent().inject(this);
         this.dataListener = dataListener;
-
-        int balanceDisplayState = prefsUtil.getValue(PrefsUtil.KEY_BALANCE_DISPLAY_STATE, SHOW_BTC);
-        isBtc = balanceDisplayState != SHOW_FIAT;
     }
 
     @Override
@@ -155,13 +150,13 @@ public class AccountChooserViewModel extends BaseViewModel {
 
     private Observable<List<ItemAccount>> getAccountList() {
         ArrayList<ItemAccount> result = new ArrayList<>();
-        result.addAll(walletAccountHelper.getHdAccounts(isBtc));
+        result.addAll(walletAccountHelper.getHdAccounts(accessState.isBtc()));
         return Observable.just(result);
     }
 
     private Observable<List<ItemAccount>> getImportedList() {
         ArrayList<ItemAccount> result = new ArrayList<>();
-        result.addAll(walletAccountHelper.getLegacyAddresses(isBtc));
+        result.addAll(walletAccountHelper.getLegacyAddresses(accessState.isBtc()));
         return Observable.just(result);
     }
 

--- a/app/src/main/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailFragment.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailFragment.java
@@ -33,9 +33,6 @@ import piuk.blockchain.android.util.PrefsUtil;
 import piuk.blockchain.android.util.ViewUtils;
 import piuk.blockchain.android.util.annotations.Thunk;
 
-import static piuk.blockchain.android.data.access.AccessState.SHOW_BTC;
-import static piuk.blockchain.android.data.access.AccessState.SHOW_FIAT;
-
 
 public class ContactDetailFragment extends Fragment implements ContactDetailViewModel.DataListener {
 
@@ -145,9 +142,9 @@ public class ContactDetailFragment extends Fragment implements ContactDetailView
     }
 
     @Override
-    public void onTransactionsUpdated(List<Object> transactions) {
+    public void onTransactionsUpdated(List<Object> transactions, boolean isBtc) {
         if (balanceAdapter == null) {
-            setUpAdapter();
+            setUpAdapter(isBtc);
         }
 
         balanceAdapter.onContactsMapChanged(
@@ -163,18 +160,14 @@ public class ContactDetailFragment extends Fragment implements ContactDetailView
         }
     }
 
-    private void setUpAdapter() {
+    private void setUpAdapter(boolean isBtc) {
         String fiatString = viewModel.getPrefsUtil().getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY);
         double lastPrice = ExchangeRateFactory.getInstance().getLastPrice(fiatString);
-
-        int balanceDisplayState =
-                viewModel.getPrefsUtil().getValue(PrefsUtil.KEY_BALANCE_DISPLAY_STATE, SHOW_BTC);
-        boolean isBTC = balanceDisplayState != SHOW_FIAT;
 
         balanceAdapter = new BalanceAdapter(
                 getActivity(),
                 lastPrice,
-                isBTC,
+                isBtc,
                 new BalanceListClickListener() {
             @Override
             public void onTransactionClicked(int correctedPosition, int absolutePosition) {
@@ -183,9 +176,7 @@ public class ContactDetailFragment extends Fragment implements ContactDetailView
 
             @Override
             public void onValueClicked(boolean isBtc) {
-                viewModel.getPrefsUtil().setValue(
-                        PrefsUtil.KEY_BALANCE_DISPLAY_STATE,
-                        isBtc ? SHOW_BTC : SHOW_FIAT);
+                viewModel.onBtcFormatChanged(isBtc);
                 balanceAdapter.onViewFormatUpdated(isBtc);
             }
 

--- a/app/src/main/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailViewModel.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailViewModel.java
@@ -22,6 +22,7 @@ import javax.inject.Inject;
 
 import io.reactivex.Observable;
 import piuk.blockchain.android.R;
+import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.contacts.ContactTransactionModel;
 import piuk.blockchain.android.data.contacts.ContactsPredicates;
 import piuk.blockchain.android.data.contacts.FctxDateComparator;
@@ -55,6 +56,7 @@ public class ContactDetailViewModel extends BaseViewModel {
     @Inject RxBus rxBus;
     @Inject StringUtils stringUtils;
     @Inject TransactionListDataManager transactionListDataManager;
+    @Inject AccessState accessState;
 
     interface DataListener {
 
@@ -74,7 +76,7 @@ public class ContactDetailViewModel extends BaseViewModel {
 
         void showDeleteUserDialog();
 
-        void onTransactionsUpdated(List<Object> transactions);
+        void onTransactionsUpdated(List<Object> transactions, boolean isBtc);
 
         void showAccountChoiceDialog(List<String> accounts, String fctxId);
 
@@ -285,6 +287,11 @@ public class ContactDetailViewModel extends BaseViewModel {
 
     }
 
+
+    void onBtcFormatChanged(boolean isBtc) {
+        accessState.setIsBtc(isBtc);
+    }
+
     private void subscribeToNotifications() {
         notificationObservable = rxBus.register(NotificationPayload.class);
         compositeDisposable.add(
@@ -366,7 +373,7 @@ public class ContactDetailViewModel extends BaseViewModel {
             }
         }
 
-        dataListener.onTransactionsUpdated(displayList);
+        dataListener.onTransactionsUpdated(displayList, accessState.isBtc());
     }
 
     private void showErrorAndQuitPage() {

--- a/app/src/main/java/piuk/blockchain/android/ui/send/SendViewModel.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/send/SendViewModel.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import io.reactivex.Observable;
 import io.reactivex.disposables.Disposable;
 import piuk.blockchain.android.R;
+import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.api.EnvironmentSettings;
 import piuk.blockchain.android.data.cache.DynamicFeeCache;
 import piuk.blockchain.android.data.contacts.ContactsPredicates;
@@ -77,9 +78,6 @@ public class SendViewModel extends BaseViewModel {
     private static final String PREF_WARN_ADVANCED_FEE = "pref_warn_advanced_fee";
     private static final String PREF_WARN_WATCH_ONLY_SPEND = "pref_warn_watch_only_spend";
 
-    public static final int SHOW_BTC = 1;
-    public static final int SHOW_FIAT = 2;
-
     @Thunk SendContract.DataListener dataListener;
 
     private MonetaryUtil monetaryUtil;
@@ -106,6 +104,7 @@ public class SendViewModel extends BaseViewModel {
     @Inject TransactionListDataManager transactionListDataManager;
     @Inject EnvironmentSettings environmentSettings;
     @Inject FeeDataManager feeDataManager;
+    @Inject AccessState accessState;
 
     SendViewModel(SendContract.DataListener dataListener, Locale locale) {
         Injector.getInstance().getDataManagerComponent().inject(this);
@@ -157,7 +156,7 @@ public class SendViewModel extends BaseViewModel {
         sendModel.btcUnit = monetaryUtil.getBTCUnit(btcUnit);
         sendModel.fiatUnit = fiatUnit;
         sendModel.btcUniti = btcUnit;
-        sendModel.isBTC = getBtcDisplayState();
+        sendModel.isBTC = accessState.isBtc();
         sendModel.exchangeRate = exchangeRate;
         sendModel.btcExchange = exchangeRateFactory.getLastPrice(sendModel.fiatUnit);
 
@@ -974,11 +973,6 @@ public class SendViewModel extends BaseViewModel {
         } else {
             showToast(R.string.invalid_private_key, ToastCustom.TYPE_ERROR);
         }
-    }
-
-    private boolean getBtcDisplayState() {
-        int BALANCE_DISPLAY_STATE = prefsUtil.getValue(PrefsUtil.KEY_BALANCE_DISPLAY_STATE, SHOW_BTC);
-        return BALANCE_DISPLAY_STATE != SHOW_FIAT;
     }
 
     private void showToast(@StringRes int message, @ToastCustom.ToastType String type) {

--- a/app/src/test/java/piuk/blockchain/android/data/datamanagers/TransactionListDataManagerTest.java
+++ b/app/src/test/java/piuk/blockchain/android/data/datamanagers/TransactionListDataManagerTest.java
@@ -7,20 +7,16 @@ import info.blockchain.wallet.payload.data.LegacyAddress;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import io.reactivex.observers.TestObserver;
-import piuk.blockchain.android.BlockchainTestApplication;
-import piuk.blockchain.android.BuildConfig;
 import piuk.blockchain.android.RxTest;
 import piuk.blockchain.android.data.rxjava.RxBus;
 import piuk.blockchain.android.data.stores.TransactionListStore;
@@ -31,8 +27,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
-@RunWith(RobolectricTestRunner.class)
 public class TransactionListDataManagerTest extends RxTest {
 
     @Mock private PayloadManager payloadManager;
@@ -250,7 +244,7 @@ public class TransactionListDataManagerTest extends RxTest {
         // Assert
         testObserver.assertTerminated();
         testObserver.assertNoValues();
-        testObserver.assertError(NullPointerException.class);
+        testObserver.assertError(NoSuchElementException.class);
     }
 
 }

--- a/app/src/test/java/piuk/blockchain/android/data/notifications/NotificationTokenManagerTest.java
+++ b/app/src/test/java/piuk/blockchain/android/data/notifications/NotificationTokenManagerTest.java
@@ -5,16 +5,11 @@ import info.blockchain.wallet.payload.data.Wallet;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import io.reactivex.Completable;
 import io.reactivex.Observable;
-import piuk.blockchain.android.BlockchainTestApplication;
-import piuk.blockchain.android.BuildConfig;
 import piuk.blockchain.android.data.access.AccessState;
 import piuk.blockchain.android.data.access.AuthEvent;
 import piuk.blockchain.android.data.rxjava.RxBus;
@@ -26,8 +21,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
-@RunWith(RobolectricTestRunner.class)
 public class NotificationTokenManagerTest {
 
     private NotificationTokenManager subject;

--- a/app/src/test/java/piuk/blockchain/android/ui/transactions/TransactionDetailViewModelTest.java
+++ b/app/src/test/java/piuk/blockchain/android/ui/transactions/TransactionDetailViewModelTest.java
@@ -23,6 +23,7 @@ import java.util.Locale;
 
 import io.reactivex.Completable;
 import io.reactivex.Observable;
+import io.reactivex.Single;
 import io.reactivex.observers.TestObserver;
 import piuk.blockchain.android.R;
 import piuk.blockchain.android.RxTest;
@@ -182,7 +183,7 @@ public class TransactionDetailViewModelTest extends RxTest {
         when(intent.getStringExtra(KEY_TRANSACTION_HASH)).thenReturn(txHash);
         when(activity.getPageIntent()).thenReturn(intent);
         when(transactionListDataManager.getTxFromHash(txHash))
-                .thenReturn(Observable.error(new Throwable()));
+                .thenReturn(Single.error(new Throwable()));
         // Act
         subject.onViewReady();
         // Assert
@@ -252,7 +253,7 @@ public class TransactionDetailViewModelTest extends RxTest {
         when(payloadManager.getPayload()).thenReturn(mockPayload);
         when(activity.getPageIntent()).thenReturn(mockIntent);
         when(transactionListDataManager.getTxFromHash("txMoved_hash"))
-                .thenReturn(Observable.just(txMoved));
+                .thenReturn(Single.just(txMoved));
         when(stringUtils.getString(R.string.transaction_detail_pending)).thenReturn("Pending (%1$s/%2$s Confirmations)");
         HashMap<String, BigInteger> inputs = new HashMap<>();
         HashMap<String, BigInteger> outputs = new HashMap<>();

--- a/app/src/test/java/piuk/blockchain/android/util/DateUtilTest.java
+++ b/app/src/test/java/piuk/blockchain/android/util/DateUtilTest.java
@@ -4,23 +4,15 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
-import piuk.blockchain.android.BlockchainTestApplication;
-import piuk.blockchain.android.BuildConfig;
-
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.junit.MatcherAssert.assertThat;
 
-@Config(sdk = 23, constants = BuildConfig.class, application = BlockchainTestApplication.class)
-@RunWith(RobolectricTestRunner.class)
 public class DateUtilTest {
 
     @Mock private Context mMockContext;

--- a/app/src/test/kotlin/piuk/blockchain/android/data/rxjava/RxBusTest.kt
+++ b/app/src/test/kotlin/piuk/blockchain/android/data/rxjava/RxBusTest.kt
@@ -7,15 +7,8 @@ import org.amshove.kluent.shouldHaveKey
 import org.amshove.kluent.shouldNotHaveKey
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
-import piuk.blockchain.android.BlockchainTestApplication
-import piuk.blockchain.android.BuildConfig
 import piuk.blockchain.android.RxTest
 
-@Config(sdk = intArrayOf(23), constants = BuildConfig::class, application = BlockchainTestApplication::class)
-@RunWith(RobolectricTestRunner::class)
 class RxBusTest : RxTest() {
 
     private lateinit var subject: RxBus

--- a/app/src/test/kotlin/piuk/blockchain/android/ui/chooser/AccountChooserViewModelTest.kt
+++ b/app/src/test/kotlin/piuk/blockchain/android/ui/chooser/AccountChooserViewModelTest.kt
@@ -14,6 +14,7 @@ import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 import piuk.blockchain.android.BlockchainTestApplication
 import piuk.blockchain.android.BuildConfig
+import piuk.blockchain.android.data.access.AccessState
 import piuk.blockchain.android.data.contacts.PaymentRequestType
 import piuk.blockchain.android.data.datamanagers.ContactsDataManager
 import piuk.blockchain.android.data.rxjava.RxBus
@@ -36,6 +37,7 @@ class AccountChooserViewModelTest {
     private var mockWalletAccountHelper: WalletAccountHelper = mock()
     private var mockStringUtils: StringUtils = mock()
     private var mockContactsManager: ContactsDataManager = mock()
+    private var mockAccessState: AccessState = mock()
 
     @Before
     @Throws(Exception::class)
@@ -181,28 +183,24 @@ class AccountChooserViewModelTest {
     }
 
     inner class MockApplicationModule(application: Application?) : ApplicationModule(application) {
-        override fun providePrefsUtil(): PrefsUtil {
-            return mockPrefsUtil
-        }
+        override fun providePrefsUtil() = mockPrefsUtil
 
-        override fun provideStringUtils(): StringUtils {
-            return mockStringUtils
-        }
+        override fun provideStringUtils() = mockStringUtils
+
+        override fun provideAccessState() = mockAccessState
     }
 
     inner class MockDataManagerModule : DataManagerModule() {
-        override fun provideWalletAccountHelper(payloadManager: PayloadManager?,
+        override fun provideWalletAccountHelper(
+                payloadManager: PayloadManager?,
                                                 prefsUtil: PrefsUtil?,
                                                 stringUtils: StringUtils?,
-                                                exchangeRateFactory: ExchangeRateFactory?): WalletAccountHelper {
-            return mockWalletAccountHelper
-        }
+                                                exchangeRateFactory: ExchangeRateFactory?
+        ) = mockWalletAccountHelper
     }
 
     inner class MockApiModule : ApiModule() {
-        override fun provideContactsManager(rxBus: RxBus?): ContactsDataManager {
-            return mockContactsManager
-        }
+        override fun provideContactsManager(rxBus: RxBus?) = mockContactsManager
     }
 
 }


### PR DESCRIPTION
Added Timber for more flexible logging, for a few reasons:

- Removes a dependency on the Android framework, meaning no excuse to use `t.printStackTrace()` instead of proper logging
- As such, this means we have to use Robolectric in less places, making testing faster and easier to set up in the first place
- No `TAG` necessary, it's inferred from the logging class
- It'll allow us to log non-fatal exceptions globally to Crashlytics if we so wish
- It's only 8 methods after ProGuard, so the impact on the APK is near-zero

Please use `Timber.d(...)` or whatever logging level you need from now on. Custom Lint rules may be added in the future to discourage use of `Log.d(...)`.

Merge #578 first!