### PR TITLE
fix(Single Task)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
         <activity
             android:name=".ui.launcher.LauncherActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:launchMode="singleTask">
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Fix issue where re-entering the app from the launcher icon would restart the app completely, which isn't a problem if you're already logged in but could prevent login under certain conditions.

Please give this one a test, I'm not 100% certain that this can't introduce weird multi-instance/activity backstack bugs but I've not seen anything in my testing.