### PR TITLE
fix(Multiaddress): Fix issue where amounts could sometimes display in…

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/auth/PinEntryFragment.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/auth/PinEntryFragment.java
@@ -114,7 +114,7 @@ public class PinEntryFragment extends BaseFragment<PinEntryView, PinEntryPresent
         if (getArguments() != null) {
             boolean showSwipeHint = getArguments().getBoolean(KEY_SHOW_SWIPE_HINT);
             if (!showSwipeHint) {
-                binding.swipeHintLayout.setVisibility(View.GONE);
+                binding.swipeHintLayout.setVisibility(View.INVISIBLE);
             }
         }
 

--- a/wallet/src/main/java/info/blockchain/wallet/multiaddress/MultiAddressFactory.java
+++ b/wallet/src/main/java/info/blockchain/wallet/multiaddress/MultiAddressFactory.java
@@ -11,8 +11,11 @@ import info.blockchain.api.data.Xpub;
 import info.blockchain.wallet.bip44.HDChain;
 import info.blockchain.wallet.exceptions.ApiException;
 import info.blockchain.wallet.multiaddress.TransactionSummary.Direction;
-import info.blockchain.wallet.payload.PayloadManager;
 import info.blockchain.wallet.payload.data.AddressLabel;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -22,8 +25,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import retrofit2.Call;
 import retrofit2.Response;
@@ -55,7 +56,7 @@ public class MultiAddressFactory {
     }
 
     private MultiAddress getMultiAddress(List<String> allActive, String onlyShow, int limit,
-        int offset) throws IOException, ApiException {
+                                         int offset) throws IOException, ApiException {
 
         getLog().info("Fetching multiaddress for {} accounts/addresses", allActive.size());
 
@@ -69,10 +70,10 @@ public class MultiAddressFactory {
     }
 
     protected Call<MultiAddress> getMultiAddress(List<String> allActive, int limit, int offset,
-        String context) {
+                                                 String context) {
         return getBlockExplorer()
-            .getMultiAddress("btc", allActive, context, FilterType.RemoveUnspendable, limit,
-                offset);
+                .getMultiAddress("btc", allActive, context, FilterType.RemoveUnspendable, limit,
+                        offset);
     }
 
     BlockExplorer getBlockExplorer() {
@@ -84,28 +85,25 @@ public class MultiAddressFactory {
     }
 
     /**
-     * @param all A list of all xpubs and legacy addresses whose transactions are to
-     * be retrieved from API.
-     * @param watchOnly A list of watch-only legacy addresses. Used to flag transactions as 'watch-only'
+     * @param all          A list of all xpubs and legacy addresses whose transactions are to
+     *                     be retrieved from API.
+     * @param watchOnly    A list of watch-only legacy addresses. Used to flag transactions as 'watch-only'
      * @param activeLegacy (Hacky! Needs a rethink) Only set this when fetching a transaction list
-     * for imported addresses, otherwise set as Null.
-     * A list of all active legacy addresses. Used for 'Imported address' transaction list.
-     * @param onlyShow Xpub or legacy address. Used to fetch transaction only relating to this
-     * address. Set as Null for a consolidated list like 'All Accounts' or 'Imported'.
-     * @param limit Maximum amount of transactions fetched
-     * @param offset Page offset
-     * @return
-     * @throws IOException
-     * @throws ApiException
+     *                     for imported addresses, otherwise set as Null.
+     *                     A list of all active legacy addresses. Used for 'Imported address' transaction list.
+     * @param onlyShow     Xpub or legacy address. Used to fetch transaction only relating to this
+     *                     address. Set as Null for a consolidated list like 'All Accounts' or 'Imported'.
+     * @param limit        Maximum amount of transactions fetched
+     * @param offset       Page offset
      */
     public List<TransactionSummary> getAccountTransactions(List<String> all,
-        List<String> watchOnly,
-        List<String> activeLegacy,
-        String onlyShow,
-        int limit,
-        int offset,
-        int startingBlockHeight)
-        throws IOException, ApiException {
+                                                           List<String> watchOnly,
+                                                           List<String> activeLegacy,
+                                                           String onlyShow,
+                                                           int limit,
+                                                           int offset,
+                                                           int startingBlockHeight)
+            throws IOException, ApiException {
 
         getLog().info("Get transactions. limit {}, offset {}", limit, offset);
 
@@ -186,6 +184,7 @@ public class MultiAddressFactory {
 
             int ret;
 
+            //noinspection UseCompareMethod -> Long.compare() can break on specific Android versions
             if (t1.getTime() > t2.getTime()) {
                 ret = BEFORE;
             } else if (t1.getTime() < t2.getTime()) {
@@ -199,10 +198,10 @@ public class MultiAddressFactory {
     }
 
     public List<TransactionSummary> summarize(List<String> ownAddressesAndXpubs,
-        List<String> watchOnlyAddresses,
-        MultiAddress multiAddress,
-        List<String> legacy,
-        int startingBlockHeight) {
+                                              List<String> watchOnlyAddresses,
+                                              MultiAddress multiAddress,
+                                              List<String> legacy,
+                                              int startingBlockHeight) {
 
         List<TransactionSummary> summaryList = new ArrayList<>();
 
@@ -276,13 +275,9 @@ public class MultiAddressFactory {
                         }
 
                         //Keep track of inputs
-                        if (txSummary.inputsMap.containsKey(inputAddr)) {
-                            BigInteger prevValue = txSummary.inputsMap.get(inputAddr)
-                                .add(inputValue);
-                            txSummary.inputsMap.put(inputAddr, prevValue);
-                        } else {
-                            txSummary.inputsMap.put(inputAddr, inputValue);
-                        }
+                        BigInteger existingBalance = txSummary.inputsMap.containsKey(inputAddr)
+                                ? txSummary.inputsMap.get(inputAddr) : BigInteger.ZERO;
+                        txSummary.inputsMap.put(inputAddr, existingBalance.add(inputValue));
 
                     } else {
                         //No input address available
@@ -309,7 +304,9 @@ public class MultiAddressFactory {
                         //inputAddr belongs to our own account - add it
                         ownAddressesAndXpubs.add(outputAddr);
                         if (xpubBody.getPath().startsWith("M/" + HDChain.RECEIVE_CHAIN + "/")) {
-                            txSummary.outputsMap.put(outputAddr, outputValue);
+                            BigInteger existingBalance = txSummary.outputsMap.containsKey(outputAddr)
+                                    ? txSummary.outputsMap.get(outputAddr) : BigInteger.ZERO;
+                            txSummary.outputsMap.put(outputAddr, existingBalance.add(outputValue));
                             txSummary.outputsXpubMap.put(outputAddr, xpubBody.getM());
                         } else {
                             //Change
@@ -318,8 +315,8 @@ public class MultiAddressFactory {
 
                     } else {
                         //If we own this address and it's not change coming back, it's a transfer
-                        if (ownAddressesAndXpubs.contains(outputAddr) && !txSummary.inputsMap
-                            .keySet().contains(outputAddr)) {
+                        if (ownAddressesAndXpubs.contains(outputAddr)
+                                && !txSummary.inputsMap.keySet().contains(outputAddr)) {
 
                             if (txSummary.getDirection() == Direction.SENT) {
                                 txSummary.setDirection(Direction.TRANSFERRED);
@@ -327,7 +324,9 @@ public class MultiAddressFactory {
 
                             //Don't add change coming back
                             if (!txSummary.inputsMap.containsKey(outputAddr)) {
-                                txSummary.outputsMap.put(outputAddr, outputValue);
+                                BigInteger existingBalance = txSummary.outputsMap.containsKey(outputAddr)
+                                        ? txSummary.outputsMap.get(outputAddr) : BigInteger.ZERO;
+                                txSummary.outputsMap.put(outputAddr, existingBalance.add(outputValue));
                             } else {
                                 changeMap.put(outputAddr, outputValue);
                             }
@@ -337,7 +336,9 @@ public class MultiAddressFactory {
                             changeMap.put(outputAddr, outputValue);
                         } else {
                             //Address does not belong to us
-                            txSummary.outputsMap.put(outputAddr, outputValue);
+                            BigInteger existingBalance = txSummary.outputsMap.containsKey(outputAddr)
+                                    ? txSummary.outputsMap.get(outputAddr) : BigInteger.ZERO;
+                            txSummary.outputsMap.put(outputAddr, existingBalance.add(outputValue));
                         }
                     }
 
@@ -353,7 +354,6 @@ public class MultiAddressFactory {
                 } else {
                     //No output address available
                     txSummary.outputsMap.put(ADDRESS_DECODE_ERROR, outputValue);
-
                 }
             }
 
@@ -364,10 +364,10 @@ public class MultiAddressFactory {
 
             //Remove input addresses not ours
             filterOwnedAddresses(
-                ownAddressesAndXpubs,
-                txSummary.inputsMap,
-                txSummary.outputsMap,
-                txSummary.getDirection());
+                    ownAddressesAndXpubs,
+                    txSummary.inputsMap,
+                    txSummary.outputsMap,
+                    txSummary.getDirection());
 
             txSummary.setHash(tx.getHash());
             txSummary.setTime(tx.getTime());
@@ -379,10 +379,10 @@ public class MultiAddressFactory {
                 txSummary.setTotal(total);
             } else {
                 BigInteger total = calculateTotalSent(
-                    txSummary.inputsMap,
-                    changeMap,
-                    tx.getFee(),
-                    txSummary.getDirection());
+                        txSummary.inputsMap,
+                        changeMap,
+                        tx.getFee(),
+                        txSummary.getDirection());
                 txSummary.setTotal(total);
             }
 
@@ -405,8 +405,8 @@ public class MultiAddressFactory {
     }
 
     private void filterOwnedAddresses(List<String> ownAddressesAndXpubs,
-        HashMap<String, BigInteger> inputsMap,
-        HashMap<String, BigInteger> outputsMap, Direction direction) {
+                                      HashMap<String, BigInteger> inputsMap,
+                                      HashMap<String, BigInteger> outputsMap, Direction direction) {
 
         Iterator<Entry<String, BigInteger>> iterator = inputsMap.entrySet().iterator();
         while (iterator.hasNext()) {
@@ -419,8 +419,7 @@ public class MultiAddressFactory {
         iterator = outputsMap.entrySet().iterator();
         while (iterator.hasNext()) {
             Entry<String, BigInteger> item = iterator.next();
-            if (!ownAddressesAndXpubs.contains(item.getKey()) && direction
-                .equals(Direction.RECEIVED)) {
+            if (!ownAddressesAndXpubs.contains(item.getKey()) && direction.equals(Direction.RECEIVED)) {
                 iterator.remove();
             }
         }
@@ -438,8 +437,8 @@ public class MultiAddressFactory {
     }
 
     private BigInteger calculateTotalSent(HashMap<String, BigInteger> inputsMap,
-        HashMap<String, BigInteger> changeMap,
-        BigInteger fee, Direction direction) {
+                                          HashMap<String, BigInteger> changeMap,
+                                          BigInteger fee, Direction direction) {
 
         BigInteger total = BigInteger.ZERO;
 


### PR DESCRIPTION
…correctly

When there is a transaction with multiple outputs to the same address, the app does not display the total amount of the transaction in the transaction history. Rather, it display only the value of one of the outputs. This is now resolved.