### PR TITLE
AND-1216 remove duplicated price code

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/account/AccountEditPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/account/AccountEditPresenter.kt
@@ -8,6 +8,7 @@ import android.support.annotation.VisibleForTesting
 import android.view.View
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.WriterException
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.BitcoinCashWallet
 import info.blockchain.wallet.coin.GenericMetadataAccount
 import info.blockchain.wallet.payload.data.Account
@@ -39,7 +40,6 @@ import piuk.blockchain.android.util.LabelUtil
 import piuk.blockchain.android.util.StringUtils
 import piuk.blockchain.android.util.extensions.addToCompositeDisposable
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.metadata.MetadataManager
 import piuk.blockchain.androidcore.data.payload.PayloadDataManager
@@ -318,17 +318,14 @@ class AccountEditPresenter @Inject internal constructor(
         val btcUnit = CryptoCurrency.BTC.name
 
         with(details) {
-            cryptoAmount =
-                currencyFormatManager.getFormattedSelectedCoinValue(pendingTransaction.bigIntAmount.toBigDecimal())
-            cryptoFee =
-                currencyFormatManager.getFormattedSelectedCoinValue(pendingTransaction.bigIntFee.toBigDecimal())
-            btcSuggestedFee =
-                currencyFormatManager.getFormattedSelectedCoinValue(pendingTransaction.bigIntFee.toBigDecimal())
+            cryptoAmount = currencyFormatManager.getFormattedSelectedCoinValue(pendingTransaction.bigIntAmount)
+            cryptoFee = currencyFormatManager.getFormattedSelectedCoinValue(pendingTransaction.bigIntFee)
+            btcSuggestedFee = currencyFormatManager.getFormattedSelectedCoinValue(pendingTransaction.bigIntFee)
             cryptoUnit = btcUnit
             this.fiatUnit = fiatUnit
 
             cryptoTotal = currencyFormatManager.getFormattedSelectedCoinValue(
-                pendingTransaction.bigIntAmount.add(pendingTransaction.bigIntFee).toBigDecimal()
+                pendingTransaction.bigIntAmount + pendingTransaction.bigIntFee
             )
 
             fiatFee = currencyFormatManager.getFormattedFiatValueFromSelectedCoinValue(

--- a/app/src/main/java/piuk/blockchain/android/ui/account/AccountPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/account/AccountPresenter.kt
@@ -498,7 +498,7 @@ class AccountPresenter @Inject internal constructor(
 
     private fun getUiString(amount: Long): String {
         return if (currencyState.isDisplayingCryptoCurrency) {
-            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(amount.toBigDecimal())
+            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(amount.toBigInteger())
         } else {
             currencyFormatManager.getFormattedFiatValueFromSelectedCoinValueWithSymbol(amount.toBigDecimal())
         }

--- a/app/src/main/java/piuk/blockchain/android/ui/account/AccountPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/account/AccountPresenter.kt
@@ -3,6 +3,7 @@ package piuk.blockchain.android.ui.account
 import android.annotation.SuppressLint
 import android.content.Intent
 import android.support.annotation.VisibleForTesting
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.BitcoinCashWallet
 import info.blockchain.wallet.api.Environment
 import info.blockchain.wallet.coin.GenericMetadataAccount
@@ -22,7 +23,6 @@ import piuk.blockchain.android.data.websocket.WebSocketService
 import piuk.blockchain.android.util.LabelUtil
 import piuk.blockchain.android.util.extensions.addToCompositeDisposable
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.currency.CurrencyState
 import piuk.blockchain.androidcore.data.metadata.MetadataManager
@@ -503,9 +503,6 @@ class AccountPresenter @Inject internal constructor(
             currencyFormatManager.getFormattedFiatValueFromSelectedCoinValueWithSymbol(amount.toBigDecimal())
         }
     }
-
-    private fun getFiatFormat(): String =
-        prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY)
 
     private fun getBalanceFromBtcAddress(address: String): Long =
         payloadDataManager.getAddressBalance(address).toLong()

--- a/app/src/main/java/piuk/blockchain/android/ui/backup/transfer/ConfirmFundsTransferPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/backup/transfer/ConfirmFundsTransferPresenter.kt
@@ -98,12 +98,10 @@ class ConfirmFundsTransferPresenter @Inject constructor(
             currencyFormatManager.getFormattedFiatValueFromSelectedCoinValueWithSymbol(totalFee.toBigDecimal())
 
         view.updateTransferAmountBtc(
-            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(
-                totalToSend.toBigDecimal()
-            )
+            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(totalToSend.toBigInteger())
         )
         view.updateTransferAmountFiat(fiatAmount)
-        view.updateFeeAmountBtc(currencyFormatManager.getFormattedSelectedCoinValueWithUnit(totalFee.toBigDecimal()))
+        view.updateFeeAmountBtc(currencyFormatManager.getFormattedSelectedCoinValueWithUnit(totalFee.toBigInteger()))
         view.updateFeeAmountFiat(fiatFee)
         view.setPaymentButtonEnabled(true)
 

--- a/app/src/main/java/piuk/blockchain/android/ui/buysell/createorder/BuySellBuildOrderPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/buysell/createorder/BuySellBuildOrderPresenter.kt
@@ -3,6 +3,7 @@ package piuk.blockchain.android.ui.buysell.createorder
 import com.crashlytics.android.answers.AddToCartEvent
 import com.crashlytics.android.answers.StartCheckoutEvent
 import info.blockchain.api.data.UnspentOutputs
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.api.data.FeeOptions
 import info.blockchain.wallet.payload.data.Account
 import io.reactivex.Observable
@@ -654,10 +655,8 @@ class BuySellBuildOrderPresenter @Inject constructor(
         return rate.multiply(maximumInCardAmount.toBigDecimal()).setScale(2, RoundingMode.DOWN)
     }
 
-    private fun getExchangeRate(currencyCode: String): BigDecimal {
-        val price = exchangeRateDataManager.getLastBtcPrice(currencyCode)
-        return BigDecimal.valueOf(price)
-    }
+    private fun getExchangeRate(currencyCode: String) =
+        exchangeRateDataManager.getLastPrice(CryptoCurrency.BTC, currencyCode).toBigDecimal()
 
     // region Observables
     private fun getExchangeRate(token: String, amount: Double, currency: String): Single<Quote> =

--- a/app/src/main/java/piuk/blockchain/android/ui/charts/ChartsPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/charts/ChartsPresenter.kt
@@ -4,7 +4,6 @@ import piuk.blockchain.android.util.extensions.addToCompositeDisposable
 import piuk.blockchain.androidcore.data.charts.ChartsDataManager
 import piuk.blockchain.androidcore.data.charts.TimeSpan
 import piuk.blockchain.androidcore.data.charts.models.ChartDatumDto
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager
 import piuk.blockchain.androidcore.utils.PrefsUtil
@@ -71,12 +70,7 @@ class ChartsPresenter @Inject constructor(
         ChartsState.Data(list, getCurrencySymbol())
 
     private fun getCurrentPrice() {
-        val price = when (view.cryptoCurrency) {
-            CryptoCurrency.BTC -> exchangeRateFactory.getLastBtcPrice(getFiatCurrency())
-            CryptoCurrency.ETHER -> exchangeRateFactory.getLastEthPrice(getFiatCurrency())
-            CryptoCurrency.BCH -> exchangeRateFactory.getLastBchPrice(getFiatCurrency())
-        }
-
+        val price = exchangeRateFactory.getLastPrice(view.cryptoCurrency, getFiatCurrency())
         view.updateCurrentPrice(getCurrencySymbol(), price)
     }
 

--- a/app/src/main/java/piuk/blockchain/android/ui/chooser/AccountChooserPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/chooser/AccountChooserPresenter.kt
@@ -1,5 +1,7 @@
 package piuk.blockchain.android.ui.chooser
 
+import info.blockchain.balance.CryptoCurrency
+import info.blockchain.balance.CryptoValue
 import info.blockchain.wallet.contacts.data.Contact
 import info.blockchain.wallet.payload.data.LegacyAddress
 import io.reactivex.Observable
@@ -104,9 +106,9 @@ class AccountChooserPresenter @Inject internal constructor(
 
             itemAccounts.add(ItemAccount().apply {
                 label = stringUtils.getString(R.string.all_accounts)
-                displayBalance = getBtcBalanceString(
+                displayBalance = getBalanceString(
                     currencyState.isDisplayingCryptoCurrency,
-                    bigIntBalance.toLong()
+                    bigIntBalance
                 )
                 absoluteBalance = bigIntBalance.toLong()
                 type = ItemAccount.TYPE.ALL_ACCOUNTS_AND_LEGACY
@@ -121,9 +123,9 @@ class AccountChooserPresenter @Inject internal constructor(
                     val bigIntBalance = payloadDataManager.importedAddressesBalance
 
                     itemAccounts.add(ItemAccount().apply {
-                        displayBalance = getBtcBalanceString(
+                        displayBalance = getBalanceString(
                             currencyState.isDisplayingCryptoCurrency,
-                            bigIntBalance.toLong()
+                            bigIntBalance
                         )
                         label = stringUtils.getString(R.string.imported_addresses)
                         absoluteBalance = bigIntBalance.toLong()
@@ -148,9 +150,9 @@ class AccountChooserPresenter @Inject internal constructor(
 
             itemAccounts.add(ItemAccount().apply {
                 label = stringUtils.getString(R.string.all_accounts)
-                displayBalance = getBtcBalanceString(
+                displayBalance = getBalanceString(
                     currencyState.isDisplayingCryptoCurrency,
-                    bigIntBalance.toLong()
+                    bigIntBalance
                 )
                 absoluteBalance = bigIntBalance.toLong()
                 type = ItemAccount.TYPE.ALL_ACCOUNTS_AND_LEGACY
@@ -165,9 +167,9 @@ class AccountChooserPresenter @Inject internal constructor(
                     val bigIntBalance = bchDataManager.getImportedAddressBalance()
 
                     itemAccounts.add(ItemAccount().apply {
-                        displayBalance = getBtcBalanceString(
+                        displayBalance = getBalanceString(
                             currencyState.isDisplayingCryptoCurrency,
-                            bigIntBalance.toLong()
+                            bigIntBalance
                         )
                         label = stringUtils.getString(R.string.imported_addresses)
                         absoluteBalance = bigIntBalance.toLong()
@@ -282,12 +284,9 @@ class AccountChooserPresenter @Inject internal constructor(
     private fun getEthAccount(): Observable<ItemAccount> =
         Observable.just(walletAccountHelper.getEthAccount()[0])
 
-    private fun getBtcBalanceString(isBtc: Boolean, btcBalance: Long): String {
-        return if (isBtc) {
-            currencyFormatManager.getFormattedBtcValueWithUnit(
-                btcBalance.toBigDecimal(),
-                BTCDenomination.SATOSHI
-            )
+    private fun getBalanceString(displayAsBtc: Boolean, btcBalance: BigInteger): String {
+        return if (displayAsBtc) {
+            currencyFormatManager.getFormattedValueWithUnit(CryptoValue(CryptoCurrency.BTC, btcBalance))
         } else {
             currencyFormatManager.getFormattedFiatValueFromBtcValueWithSymbol(
                 coinValue = btcBalance.toBigDecimal(),

--- a/app/src/main/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailPresenter.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailPresenter.java
@@ -34,14 +34,12 @@ import piuk.blockchain.androidcore.data.contacts.comparators.FctxDateComparator;
 import piuk.blockchain.androidcore.data.currency.BTCDenomination;
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager;
 import piuk.blockchain.androidcore.data.currency.CurrencyState;
-import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager;
 import piuk.blockchain.androidcore.data.payload.PayloadDataManager;
 import piuk.blockchain.androidcore.data.rxjava.RxBus;
 import piuk.blockchain.androidcore.utils.PrefsUtil;
 import timber.log.Timber;
 
 import static piuk.blockchain.android.ui.contacts.list.ContactsListActivity.KEY_BUNDLE_CONTACT_ID;
-
 
 public class ContactDetailPresenter extends BasePresenter<ContactDetailView> {
 
@@ -54,7 +52,6 @@ public class ContactDetailPresenter extends BasePresenter<ContactDetailView> {
     private RxBus rxBus;
     private TransactionListDataManager transactionListDataManager;
     private CurrencyState currencyState;
-    private ExchangeRateDataManager exchangeRateFactory;
     private CurrencyFormatManager currencyFormatManager;
 
     @Inject
@@ -63,7 +60,6 @@ public class ContactDetailPresenter extends BasePresenter<ContactDetailView> {
                            PrefsUtil prefsUtil,
                            RxBus rxBus,
                            TransactionListDataManager transactionListDataManager,
-                           ExchangeRateDataManager exchangeRateFactory,
                            CurrencyState currencyState,
                            CurrencyFormatManager currencyFormatManager) {
 
@@ -72,7 +68,6 @@ public class ContactDetailPresenter extends BasePresenter<ContactDetailView> {
         this.prefsUtil = prefsUtil;
         this.rxBus = rxBus;
         this.transactionListDataManager = transactionListDataManager;
-        this.exchangeRateFactory = exchangeRateFactory;
         this.currencyState = currencyState;
         this.currencyFormatManager = currencyFormatManager;
     }
@@ -382,10 +377,6 @@ public class ContactDetailPresenter extends BasePresenter<ContactDetailView> {
                 BigDecimal.valueOf(btcBalance), null, BTCDenomination.SATOSHI);
     }
 
-    private String getFiatCurrency() {
-        return prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY);
-    }
-
     private void showErrorAndQuitPage() {
         getView().showToast(R.string.contacts_not_found_error, ToastCustom.TYPE_ERROR);
         getView().finishPage();
@@ -395,9 +386,5 @@ public class ContactDetailPresenter extends BasePresenter<ContactDetailView> {
     public void onViewDestroyed() {
         super.onViewDestroyed();
         rxBus.unregister(NotificationPayload.class, notificationObservable);
-    }
-
-    public double getEthExchangeRate() {
-        return exchangeRateFactory.getLastEthPrice(getFiatCurrency());
     }
 }

--- a/app/src/main/java/piuk/blockchain/android/ui/dashboard/DashboardPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/dashboard/DashboardPresenter.kt
@@ -26,6 +26,7 @@ import piuk.blockchain.androidcore.data.currency.BTCDenomination
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.currency.ETHDenomination
 import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager
+import piuk.blockchain.androidcore.data.exchangerate.toFiat
 import piuk.blockchain.androidcore.data.payload.PayloadDataManager
 import piuk.blockchain.androidcore.data.rxjava.RxBus
 import piuk.blockchain.androidcore.utils.PrefsUtil
@@ -199,8 +200,8 @@ class DashboardPresenter @Inject constructor(
                         val bchFiat = calculateFiatValue(bchBalance, fiatCurrency)
                         val ethFiat = calculateFiatValue(ethBalance, fiatCurrency)
 
-                        val totalDouble = btcFiat + ethFiat + bchFiat
-                        val totalString = getFormattedCurrencyString(totalDouble)
+                        val total = btcFiat + ethFiat + bchFiat
+                        val totalString = getFormattedCurrencyString(total.toDouble())
 
                         Logging.logCustom(
                             BalanceLoadedEvent(
@@ -213,17 +214,17 @@ class DashboardPresenter @Inject constructor(
                         cachedData = PieChartsState.Data(
                             fiatSymbol = getCurrencySymbol(),
                             bitcoin = PieChartsState.DataPoint(
-                                fiatValue = BigDecimal.valueOf(btcFiat),
+                                fiatValue = btcFiat,
                                 fiatValueString = getFiatString(btcBalance),
                                 cryptoValueString = getBalanceString(btcBalance)
                             ),
                             bitcoinCash = PieChartsState.DataPoint(
-                                fiatValue = BigDecimal.valueOf(bchFiat),
+                                fiatValue = bchFiat,
                                 fiatValueString = getFiatString(bchBalance),
                                 cryptoValueString = getBalanceString(bchBalance)
                             ),
                             ether = PieChartsState.DataPoint(
-                                fiatValue = BigDecimal.valueOf(ethFiat),
+                                fiatValue = ethFiat,
                                 fiatValueString = getFiatString(ethBalance),
                                 cryptoValueString = getBalanceString(ethBalance)
                             ),
@@ -241,7 +242,7 @@ class DashboardPresenter @Inject constructor(
     private fun calculateFiatValue(
         cryptoValue: CryptoValue,
         fiatCurrency: String
-    ) = exchangeRateFactory.getLastPrice(cryptoValue.currency, fiatCurrency) * cryptoValue.toMajorUnitDouble()
+    ) = cryptoValue.toFiat(exchangeRateFactory, fiatCurrency)
 
     private fun showAnnouncement(index: Int, announcementData: AnnouncementData) {
         displayList.add(index, announcementData)

--- a/app/src/main/java/piuk/blockchain/android/ui/receive/ReceivePresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/receive/ReceivePresenter.kt
@@ -369,11 +369,7 @@ class ReceivePresenter @Inject internal constructor(
      * @return BTC, mBTC or bits relative to what is set in [CurrencyFormatManager]
      */
     private fun getTextFromSatoshis(satoshis: Long): String {
-        var displayAmount = currencyFormatManager.getFormattedSelectedCoinValue(
-            satoshis.toBigDecimal(),
-            null,
-            BTCDenomination.SATOSHI
-        )
+        var displayAmount = currencyFormatManager.getFormattedSelectedCoinValue(satoshis.toBigInteger())
         displayAmount = displayAmount.replace(".", getDefaultDecimalSeparator())
         return displayAmount
     }

--- a/app/src/main/java/piuk/blockchain/android/ui/send/SendPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/send/SendPresenter.kt
@@ -6,6 +6,7 @@ import android.text.Editable
 import android.widget.EditText
 import com.fasterxml.jackson.databind.ObjectMapper
 import info.blockchain.api.data.UnspentOutputs
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.api.Environment
 import info.blockchain.wallet.api.data.FeeOptions
 import info.blockchain.wallet.coin.GenericMetadataAccount
@@ -40,7 +41,6 @@ import piuk.blockchain.android.util.StringUtils
 import piuk.blockchain.android.util.extensions.addToCompositeDisposable
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
 import piuk.blockchain.androidcore.data.currency.BTCDenomination
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.currency.CurrencyState
 import piuk.blockchain.androidcore.data.currency.ETHDenomination
@@ -759,20 +759,20 @@ class SendPresenter @Inject constructor(
             CryptoCurrency.BTC -> {
                 details.isLargeTransaction = isLargeTransaction()
                 details.btcSuggestedFee = currencyFormatManager.getTextFromSatoshis(
-                    absoluteSuggestedFee.toLong(),
+                    absoluteSuggestedFee,
                     getDefaultDecimalSeparator()
                 )
 
                 details.cryptoTotal = currencyFormatManager.getTextFromSatoshis(
-                    pendingTransaction.total.toLong(),
+                    pendingTransaction.total,
                     getDefaultDecimalSeparator()
                 )
                 details.cryptoAmount = currencyFormatManager.getTextFromSatoshis(
-                    pendingTransaction.bigIntAmount.toLong(),
+                    pendingTransaction.bigIntAmount,
                     getDefaultDecimalSeparator()
                 )
                 details.cryptoFee = currencyFormatManager.getTextFromSatoshis(
-                    pendingTransaction.bigIntFee.toLong(),
+                    pendingTransaction.bigIntFee,
                     getDefaultDecimalSeparator()
                 )
 
@@ -825,15 +825,15 @@ class SendPresenter @Inject constructor(
             CryptoCurrency.BCH -> {
 
                 details.cryptoTotal = currencyFormatManager.getTextFromSatoshis(
-                    pendingTransaction.total.toLong(),
+                    pendingTransaction.total,
                     getDefaultDecimalSeparator()
                 )
                 details.cryptoAmount = currencyFormatManager.getTextFromSatoshis(
-                    pendingTransaction.bigIntAmount.toLong(),
+                    pendingTransaction.bigIntAmount,
                     getDefaultDecimalSeparator()
                 )
                 details.cryptoFee = currencyFormatManager.getTextFromSatoshis(
-                    pendingTransaction.bigIntFee.toLong(),
+                    pendingTransaction.bigIntFee,
                     getDefaultDecimalSeparator()
                 )
 
@@ -1092,8 +1092,7 @@ class SendPresenter @Inject constructor(
 
         when (currencyState.cryptoCurrency) {
             CryptoCurrency.BTC -> {
-                cryptoPrice =
-                    currencyFormatManager.getFormattedSelectedCoinValue(absoluteSuggestedFee.toBigDecimal())
+                cryptoPrice = currencyFormatManager.getFormattedSelectedCoinValue(absoluteSuggestedFee)
                 fiatPrice =
                     currencyFormatManager.getFormattedFiatValueFromSelectedCoinValueWithSymbol(
                         absoluteSuggestedFee.toBigDecimal()
@@ -1108,8 +1107,7 @@ class SendPresenter @Inject constructor(
                 )
             }
             CryptoCurrency.BCH -> {
-                cryptoPrice =
-                    currencyFormatManager.getFormattedSelectedCoinValue(absoluteSuggestedFee.toBigDecimal())
+                cryptoPrice = currencyFormatManager.getFormattedSelectedCoinValue(absoluteSuggestedFee)
                 fiatPrice =
                     currencyFormatManager.getFormattedFiatValueFromSelectedCoinValueWithSymbol(
                         absoluteSuggestedFee.toBigDecimal()
@@ -1294,7 +1292,7 @@ class SendPresenter @Inject constructor(
             amount = sweepableAmount
             view?.updateCryptoAmount(
                 currencyFormatManager.getTextFromSatoshis(
-                    sweepableAmount.toLong(),
+                    sweepableAmount,
                     getDefaultDecimalSeparator()
                 )
             )
@@ -1413,7 +1411,7 @@ class SendPresenter @Inject constructor(
 
             // Convert to correct units
             try {
-                amount = currencyFormatManager.getFormattedSelectedCoinValue(amount.toBigDecimal())
+                amount = currencyFormatManager.getFormattedSelectedCoinValue(amount.toBigInteger())
                 view?.updateCryptoAmount(amount)
 
                 val fiat = when (currencyState.cryptoCurrency) {
@@ -2013,7 +2011,7 @@ class SendPresenter @Inject constructor(
     private fun isLargeTransaction(): Boolean {
         val valueString = currencyFormatManager.getFiatFormat("USD")
             .format(
-                exchangeRateFactory.getLastBtcPrice("USD") *
+                exchangeRateFactory.getLastPrice(CryptoCurrency.BTC, "USD") *
                     absoluteSuggestedFee.toDouble() / 1e8
             )
         val usdValue =

--- a/app/src/main/java/piuk/blockchain/android/ui/send/SendPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/send/SendPresenter.kt
@@ -1128,7 +1128,7 @@ class SendPresenter @Inject constructor(
         // Format for display
         view.updateMaxAvailable(
             stringUtils.getString(R.string.max_available) +
-                " ${currencyFormatManager.getFormattedSelectedCoinValueWithUnit(maxAvailable.toBigDecimal())}"
+                " ${currencyFormatManager.getFormattedSelectedCoinValueWithUnit(maxAvailable)}"
         )
 
         if (balanceAfterFee <= Payment.DUST) {

--- a/app/src/main/java/piuk/blockchain/android/ui/shapeshift/newexchange/NewExchangePresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/shapeshift/newexchange/NewExchangePresenter.kt
@@ -1,6 +1,7 @@
 package piuk.blockchain.android.ui.shapeshift.newexchange
 
 import info.blockchain.api.data.UnspentOutputs
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.api.data.FeeOptions
 import info.blockchain.wallet.coin.GenericMetadataAccount
 import info.blockchain.wallet.payload.data.Account
@@ -24,7 +25,6 @@ import piuk.blockchain.android.ui.shapeshift.models.ShapeShiftData
 import piuk.blockchain.android.util.StringUtils
 import piuk.blockchain.android.util.extensions.addToCompositeDisposable
 import piuk.blockchain.androidbuysell.datamanagers.BuyDataManager
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager
 import piuk.blockchain.androidcore.data.payload.PayloadDataManager
@@ -390,15 +390,7 @@ class NewExchangePresenter @Inject constructor(
     private fun getExchangeRate(
         cryptoCurrency: CryptoCurrency,
         currencyCode: String
-    ): BigDecimal {
-        val price = when (cryptoCurrency) {
-            CryptoCurrency.BTC -> exchangeRateFactory.getLastBtcPrice(currencyCode)
-            CryptoCurrency.ETHER -> exchangeRateFactory.getLastEthPrice(currencyCode)
-            CryptoCurrency.BCH -> exchangeRateFactory.getLastBchPrice(currencyCode)
-        }
-
-        return BigDecimal.valueOf(price)
-    }
+    ) = exchangeRateFactory.getLastPrice(cryptoCurrency, currencyCode).toBigDecimal()
 
     private fun getUnspentApiResponseBtc(address: String): Observable<UnspentOutputs> {
         return if (payloadDataManager.getAddressBalance(address).toLong() > 0) {

--- a/app/src/main/java/piuk/blockchain/android/ui/shapeshift/overview/ShapeshiftPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/shapeshift/overview/ShapeshiftPresenter.kt
@@ -1,5 +1,6 @@
 package piuk.blockchain.android.ui.shapeshift.overview
 
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.shapeshift.data.Trade
 import info.blockchain.wallet.shapeshift.data.TradeStatusResponse
 import io.reactivex.Observable
@@ -60,10 +61,11 @@ class ShapeShiftPresenter @Inject constructor(
 
     internal fun onResume() {
         // Here we check the Fiat and Btc formats and let the UI handle any potential updates
+        val fiat = getFiatCurrency()
         view.onExchangeRateUpdated(
-            getLastBtcPrice(getFiatCurrency()),
-            getLastEthPrice(getFiatCurrency()),
-            getLastBchPrice(getFiatCurrency()),
+            exchangeRateFactory.getLastPrice(CryptoCurrency.BTC, fiat),
+            exchangeRateFactory.getLastPrice(CryptoCurrency.ETHER, fiat),
+            exchangeRateFactory.getLastPrice(CryptoCurrency.BCH, fiat),
             currencyState.isDisplayingCryptoCurrency
         )
         view.onViewTypeChanged(currencyState.isDisplayingCryptoCurrency)
@@ -163,12 +165,6 @@ class ShapeShiftPresenter @Inject constructor(
         Trade.STATUS.COMPLETE, Trade.STATUS.FAILED, Trade.STATUS.RESOLVED -> true
         else -> true
     }
-
-    private fun getLastBtcPrice(fiat: String) = exchangeRateFactory.getLastBtcPrice(fiat)
-
-    private fun getLastEthPrice(fiat: String) = exchangeRateFactory.getLastEthPrice(fiat)
-
-    private fun getLastBchPrice(fiat: String) = exchangeRateFactory.getLastBchPrice(fiat)
 
     private fun getFiatCurrency() =
         prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY)

--- a/app/src/main/java/piuk/blockchain/android/ui/transactions/TransactionDetailPresenter.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/transactions/TransactionDetailPresenter.java
@@ -273,7 +273,7 @@ public class TransactionDetailPresenter extends BasePresenter<TransactionDetailV
 
             TransactionDetailModel transactionDetailModel = new TransactionDetailModel(
                     label,
-                    currencyFormatManager.getFormattedSelectedCoinValue(BigDecimal.valueOf(value), null, BTCDenomination.SATOSHI),
+                    currencyFormatManager.getFormattedSelectedCoinValue(BigInteger.valueOf(value)),
                     unit);
 
             if (transactionDetailModel.getAddress().equals(MultiAddressFactory.ADDRESS_DECODE_ERROR)) {
@@ -321,7 +321,7 @@ public class TransactionDetailPresenter extends BasePresenter<TransactionDetailV
 
             TransactionDetailModel transactionDetailModel = new TransactionDetailModel(
                     label,
-                    currencyFormatManager.getFormattedSelectedCoinValue(BigDecimal.valueOf(value), null, BTCDenomination.SATOSHI),
+                    currencyFormatManager.getFormattedSelectedCoinValue(BigInteger.valueOf(value)),
                     unit);
 
             if (displayModel != null && displayable.getDirection().equals(Direction.SENT)) {

--- a/app/src/test/java/piuk/blockchain/android/ui/account/AccountEditPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/account/AccountEditPresenterTest.kt
@@ -55,7 +55,6 @@ import piuk.blockchain.androidcore.data.metadata.MetadataManager
 import piuk.blockchain.androidcore.data.payload.PayloadDataManager
 import piuk.blockchain.androidcore.utils.PrefsUtil
 import piuk.blockchain.androidcoreui.ui.customviews.ToastCustom
-import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.ArrayList
 import java.util.Arrays
@@ -205,7 +204,7 @@ class AccountEditPresenterTest {
             .thenReturn("USD")
         whenever(sendDataManager.estimateSize(anyInt(), anyInt())).thenReturn(1337)
 
-        whenever(currencyFormatManager.getFormattedSelectedCoinValue(BigDecimal.TEN))
+        whenever(currencyFormatManager.getFormattedSelectedCoinValue(BigInteger.TEN))
             .thenReturn("")
 
         // Act

--- a/app/src/test/java/piuk/blockchain/android/ui/account/AccountPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/account/AccountPresenterTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.api.Environment
 import info.blockchain.wallet.coin.GenericMetadataAccount
 import info.blockchain.wallet.exceptions.DecryptionException
@@ -38,8 +39,6 @@ import piuk.blockchain.android.data.datamanagers.TransferFundsDataManager
 import piuk.blockchain.android.ui.account.AccountPresenter.Companion.KEY_WARN_TRANSFER_ALL
 import piuk.blockchain.android.ui.send.PendingTransaction
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
-import piuk.blockchain.androidcore.data.currency.BTCDenomination
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.currency.CurrencyState
 import piuk.blockchain.androidcore.data.metadata.MetadataManager
@@ -47,7 +46,6 @@ import piuk.blockchain.androidcore.data.payload.PayloadDataManager
 import piuk.blockchain.androidcore.utils.PrefsUtil
 import piuk.blockchain.androidcoreui.ui.customviews.ToastCustom
 import piuk.blockchain.androidcoreui.utils.AppUtil
-import java.math.BigDecimal
 import java.math.BigInteger
 import java.util.Locale
 
@@ -472,11 +470,7 @@ class AccountPresenterTest {
 
         whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.BTC)
         whenever(
-            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(
-                BigDecimal.valueOf(0),
-                null,
-                BTCDenomination.SATOSHI
-            )
+            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(BigInteger.ZERO)
         ).thenReturn("")
 
         // Act

--- a/app/src/test/java/piuk/blockchain/android/ui/backup/transfer/ConfirmFundsTransferPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/backup/transfer/ConfirmFundsTransferPresenterTest.kt
@@ -108,15 +108,11 @@ class ConfirmFundsTransferPresenterTest {
 
         whenever(stringUtils.getQuantityString(anyInt(), anyInt())).thenReturn("test string")
         whenever(
-            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(
-                BigDecimal.valueOf(total)
-            )
+            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(total.toBigInteger())
         )
             .thenReturn("1.0 BTC")
         whenever(
-            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(
-                BigDecimal.valueOf(fee)
-            )
+            currencyFormatManager.getFormattedSelectedCoinValueWithUnit(fee.toBigInteger())
         )
             .thenReturn("0.0001 BTC")
         whenever(

--- a/app/src/test/java/piuk/blockchain/android/ui/charts/ChartsPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/charts/ChartsPresenterTest.kt
@@ -50,7 +50,7 @@ class ChartsPresenterTest {
         whenever(view.locale).thenReturn(Locale.UK)
         whenever(prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY))
             .thenReturn(fiat)
-        whenever(exchangeRateFactory.getLastBtcPrice(fiat)).thenReturn(13950.0)
+        whenever(exchangeRateFactory.getLastPrice(CryptoCurrency.BTC, fiat)).thenReturn(13950.0)
         whenever(chartsDataManager.getMonthPrice(CryptoCurrency.BTC, fiat))
             .thenReturn(Observable.just(chartData))
         // Act
@@ -67,7 +67,7 @@ class ChartsPresenterTest {
 //        verifyNoMoreInteractions(view)
         verify(chartsDataManager).getMonthPrice(CryptoCurrency.BTC, fiat)
         verifyNoMoreInteractions(chartsDataManager)
-        verify(exchangeRateFactory).getLastBtcPrice(fiat)
+        verify(exchangeRateFactory).getLastPrice(CryptoCurrency.BTC, fiat)
         verifyNoMoreInteractions(exchangeRateFactory)
         verify(prefsUtil, atLeastOnce()).getValue(
             PrefsUtil.KEY_SELECTED_FIAT,
@@ -84,7 +84,7 @@ class ChartsPresenterTest {
         whenever(view.locale).thenReturn(Locale.UK)
         whenever(prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY))
             .thenReturn(fiat)
-        whenever(exchangeRateFactory.getLastBtcPrice(fiat)).thenReturn(13950.0)
+        whenever(exchangeRateFactory.getLastPrice(CryptoCurrency.BTC, fiat)).thenReturn(13950.0)
         whenever(chartsDataManager.getMonthPrice(CryptoCurrency.BTC, fiat))
             .thenReturn(Observable.error(Throwable()))
         // Act
@@ -100,7 +100,7 @@ class ChartsPresenterTest {
 //        verifyNoMoreInteractions(view)
         verify(chartsDataManager).getMonthPrice(CryptoCurrency.BTC, fiat)
         verifyNoMoreInteractions(chartsDataManager)
-        verify(exchangeRateFactory).getLastBtcPrice(fiat)
+        verify(exchangeRateFactory).getLastPrice(CryptoCurrency.BTC, fiat)
         verifyNoMoreInteractions(exchangeRateFactory)
         verify(prefsUtil, atLeastOnce()).getValue(
             PrefsUtil.KEY_SELECTED_FIAT,
@@ -118,7 +118,7 @@ class ChartsPresenterTest {
         whenever(view.locale).thenReturn(Locale.UK)
         whenever(prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY))
             .thenReturn(fiat)
-        whenever(exchangeRateFactory.getLastBtcPrice(fiat)).thenReturn(13950.0)
+        whenever(exchangeRateFactory.getLastPrice(CryptoCurrency.BTC, fiat)).thenReturn(13950.0)
         whenever(chartsDataManager.getDayPrice(CryptoCurrency.BTC, fiat))
             .thenReturn(Observable.just(chartData))
         // Act
@@ -135,7 +135,7 @@ class ChartsPresenterTest {
 //        verifyNoMoreInteractions(view)
         verify(chartsDataManager).getDayPrice(CryptoCurrency.BTC, fiat)
         verifyNoMoreInteractions(chartsDataManager)
-        verify(exchangeRateFactory).getLastBtcPrice(fiat)
+        verify(exchangeRateFactory).getLastPrice(CryptoCurrency.BTC, fiat)
         verifyNoMoreInteractions(exchangeRateFactory)
         verify(prefsUtil, atLeastOnce()).getValue(
             PrefsUtil.KEY_SELECTED_FIAT,
@@ -153,7 +153,7 @@ class ChartsPresenterTest {
         whenever(view.locale).thenReturn(Locale.UK)
         whenever(prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY))
             .thenReturn(fiat)
-        whenever(exchangeRateFactory.getLastEthPrice(fiat)).thenReturn(1281.78)
+        whenever(exchangeRateFactory.getLastPrice(CryptoCurrency.ETHER, fiat)).thenReturn(1281.78)
         whenever(chartsDataManager.getWeekPrice(CryptoCurrency.ETHER, fiat))
             .thenReturn(Observable.just(chartData))
         // Act
@@ -170,7 +170,7 @@ class ChartsPresenterTest {
 //        verifyNoMoreInteractions(view)
         verify(chartsDataManager).getWeekPrice(CryptoCurrency.ETHER, fiat)
         verifyNoMoreInteractions(chartsDataManager)
-        verify(exchangeRateFactory).getLastEthPrice(fiat)
+        verify(exchangeRateFactory).getLastPrice(CryptoCurrency.ETHER, fiat)
         verifyNoMoreInteractions(exchangeRateFactory)
         verify(prefsUtil, atLeastOnce()).getValue(
             PrefsUtil.KEY_SELECTED_FIAT,
@@ -188,7 +188,7 @@ class ChartsPresenterTest {
         whenever(view.locale).thenReturn(Locale.UK)
         whenever(prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY))
             .thenReturn(fiat)
-        whenever(exchangeRateFactory.getLastEthPrice(fiat)).thenReturn(1281.78)
+        whenever(exchangeRateFactory.getLastPrice(CryptoCurrency.ETHER, fiat)).thenReturn(1281.78)
         whenever(chartsDataManager.getYearPrice(CryptoCurrency.ETHER, fiat))
             .thenReturn(Observable.just(chartData))
         // Act
@@ -205,7 +205,7 @@ class ChartsPresenterTest {
 //        verifyNoMoreInteractions(view)
         verify(chartsDataManager).getYearPrice(CryptoCurrency.ETHER, fiat)
         verifyNoMoreInteractions(chartsDataManager)
-        verify(exchangeRateFactory).getLastEthPrice(fiat)
+        verify(exchangeRateFactory).getLastPrice(CryptoCurrency.ETHER, fiat)
         verifyNoMoreInteractions(exchangeRateFactory)
         verify(prefsUtil, atLeastOnce()).getValue(
             PrefsUtil.KEY_SELECTED_FIAT,
@@ -223,7 +223,7 @@ class ChartsPresenterTest {
         whenever(view.locale).thenReturn(Locale.UK)
         whenever(prefsUtil.getValue(PrefsUtil.KEY_SELECTED_FIAT, PrefsUtil.DEFAULT_CURRENCY))
             .thenReturn(fiat)
-        whenever(exchangeRateFactory.getLastBchPrice(fiat)).thenReturn(1281.78)
+        whenever(exchangeRateFactory.getLastPrice(CryptoCurrency.BCH, fiat)).thenReturn(1281.78)
         whenever(chartsDataManager.getAllTimePrice(CryptoCurrency.BCH, fiat))
             .thenReturn(Observable.just(chartData))
         // Act
@@ -240,7 +240,7 @@ class ChartsPresenterTest {
 //        verifyNoMoreInteractions(view)
         verify(chartsDataManager).getAllTimePrice(CryptoCurrency.BCH, fiat)
         verifyNoMoreInteractions(chartsDataManager)
-        verify(exchangeRateFactory).getLastBchPrice(fiat)
+        verify(exchangeRateFactory).getLastPrice(CryptoCurrency.BCH, fiat)
         verifyNoMoreInteractions(exchangeRateFactory)
         verify(prefsUtil, atLeastOnce()).getValue(
             PrefsUtil.KEY_SELECTED_FIAT,

--- a/app/src/test/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/contacts/detail/ContactDetailPresenterTest.kt
@@ -36,7 +36,6 @@ import piuk.blockchain.android.ui.contacts.list.ContactsListActivity.KEY_BUNDLE_
 import piuk.blockchain.androidcore.data.contacts.ContactsDataManager
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.currency.CurrencyState
-import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager
 import piuk.blockchain.androidcore.data.payload.PayloadDataManager
 import piuk.blockchain.androidcore.data.rxjava.RxBus
 import piuk.blockchain.androidcore.utils.PrefsUtil
@@ -54,7 +53,6 @@ class ContactDetailPresenterTest {
     private val mockPrefsUtil: PrefsUtil = mock()
     private val mockRxBus: RxBus = mock()
     private val mockTransactionListDataManager: TransactionListDataManager = mock()
-    private val mockExchangeRateFactory: ExchangeRateDataManager = mock()
     private val mockCurrencyState: CurrencyState = mock()
     private val currencyFormatManager: CurrencyFormatManager = mock()
 
@@ -66,7 +64,6 @@ class ContactDetailPresenterTest {
             mockPrefsUtil,
             mockRxBus,
             mockTransactionListDataManager,
-            mockExchangeRateFactory,
             mockCurrencyState,
             currencyFormatManager
         )

--- a/app/src/test/java/piuk/blockchain/android/ui/receive/ReceivePresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/receive/ReceivePresenterTest.kt
@@ -2,6 +2,7 @@ package piuk.blockchain.android.ui.receive
 
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
+import info.blockchain.balance.CryptoCurrency
 import info.blockchain.wallet.BlockchainFramework
 import info.blockchain.wallet.FrameworkInterface
 import info.blockchain.wallet.api.Environment
@@ -33,7 +34,6 @@ import piuk.blockchain.android.data.bitcoincash.BchDataManager
 import piuk.blockchain.android.data.datamanagers.QrCodeDataManager
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
 import piuk.blockchain.androidcore.data.currency.BTCDenomination
-import info.blockchain.balance.CryptoCurrency
 import piuk.blockchain.androidcore.data.currency.CurrencyFormatManager
 import piuk.blockchain.androidcore.data.currency.CurrencyState
 import piuk.blockchain.androidcore.data.ethereum.datastores.EthDataStore
@@ -43,6 +43,7 @@ import piuk.blockchain.androidcore.utils.PrefsUtil
 import piuk.blockchain.androidcoreui.ui.customviews.ToastCustom
 import retrofit2.Retrofit
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.Locale
 
 class ReceivePresenterTest {
@@ -629,9 +630,7 @@ class ReceivePresenterTest {
 
         whenever(
             currencyFormatManager.getFormattedSelectedCoinValue(
-                BigDecimal.valueOf(100000000L),
-                null,
-                BTCDenomination.SATOSHI
+                BigInteger.valueOf(100000000L)
             )
         )
             .thenReturn("1.0")

--- a/balance/src/main/kotlin/info/blockchain/balance/CryptoValue.kt
+++ b/balance/src/main/kotlin/info/blockchain/balance/CryptoValue.kt
@@ -31,11 +31,14 @@ data class CryptoValue(
         fun bitcoinCashFromSatoshis(satoshi: Long) = CryptoValue(CryptoCurrency.BCH, satoshi.toBigInteger())
         fun etherFromWei(wei: Long) = CryptoValue(CryptoCurrency.ETHER, wei.toBigInteger())
 
-        fun bitcoinFromMajor(bitcoin: Int) = fromMajor(CryptoCurrency.BTC, bitcoin.toBigDecimal())
+        fun bitcoinFromMajor(bitcoin: Int) = bitcoinFromMajor(bitcoin.toBigDecimal())
+        fun bitcoinFromMajor(bitcoin: BigDecimal) = fromMajor(CryptoCurrency.BTC, bitcoin)
 
-        fun bitcoinCashFromMajor(bitcoinCash: Int) = fromMajor(CryptoCurrency.BCH, bitcoinCash.toBigDecimal())
+        fun bitcoinCashFromMajor(bitcoinCash: Int) = bitcoinCashFromMajor(bitcoinCash.toBigDecimal())
+        fun bitcoinCashFromMajor(bitcoin: BigDecimal) = fromMajor(CryptoCurrency.BCH, bitcoin)
 
-        fun etherFromMajor(ether: Long) = fromMajor(CryptoCurrency.ETHER, ether.toBigDecimal())
+        fun etherFromMajor(ether: Long) = etherFromMajor(ether.toBigDecimal())
+        fun etherFromMajor(ether: BigDecimal) = fromMajor(CryptoCurrency.ETHER, ether)
 
         private fun fromMajor(
             currency: CryptoCurrency,

--- a/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManager.kt
@@ -84,23 +84,14 @@ class CurrencyFormatManager @Inject constructor(
     fun getFormattedSelectedCoinValue(coinValue: BigInteger) =
         getFormattedCoinValue(CryptoValue(currencyState.cryptoCurrency, coinValue))
 
-    fun getFormattedCoinValue(cryptoValue: CryptoValue) = currencyFormatUtil.format(cryptoValue)
+    fun getFormattedCoinValue(cryptoValue: CryptoValue) =
+        currencyFormatUtil.format(cryptoValue, CurrencyFormatUtil.Precision.Full)
 
-    fun getFormattedSelectedCoinValueWithUnit(
-        coinValue: BigDecimal,
-        convertEthDenomination: ETHDenomination? = null,
-        convertBtcDenomination: BTCDenomination? = BTCDenomination.SATOSHI
-    ): String {
-        val convertedCoinValue =
-            getConvertedCoinValue(coinValue, convertEthDenomination, convertBtcDenomination)
+    fun getFormattedSelectedCoinValueWithUnit(coinValue: BigInteger) =
+        getFormattedCoinValueWithUnit(CryptoValue(currencyState.cryptoCurrency, coinValue))
 
-        return when (currencyState.cryptoCurrency) {
-            CryptoCurrency.BTC -> currencyFormatUtil.formatBtcWithUnit(convertedCoinValue)
-            CryptoCurrency.ETHER -> currencyFormatUtil.formatEthWithUnit(convertedCoinValue)
-            CryptoCurrency.BCH -> currencyFormatUtil.formatBchWithUnit(convertedCoinValue)
-            else -> throw IllegalArgumentException(currencyState.cryptoCurrency.toString() + " not supported.")
-        }
-    }
+    fun getFormattedCoinValueWithUnit(cryptoValue: CryptoValue) =
+        currencyFormatUtil.formatWithUnit(cryptoValue, CurrencyFormatUtil.Precision.Full)
 
     /**
      * @return Formatted String of crypto amount from fiat currency amount.

--- a/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManager.kt
@@ -81,34 +81,10 @@ class CurrencyFormatManager @Inject constructor(
         }
     }
 
-    /**
-     * Accepts a [BigDecimal] value in Satoshis/Wei and returns the display amount as a [String]
-     * based on the chosen denomination type.
-     *
-     * eg. 10_000 Satoshi -> "0.0001" when unit == UNIT_BTC
-     * eg. 1_000_000_000_000_000_000 Wei -> "1.0" when unit == UNIT_ETH
-     *
-     * TODO: Note: a default denomination of SATOSHI was set since this method is used in so many places.
-     * Not technically correct and should be improved.
-     *
-     * @param value The amount to be formatted in Satoshis
-     * @return An amount formatted as a [String]
-     */
-    fun getFormattedSelectedCoinValue(
-        coinValue: BigDecimal,
-        convertEthDenomination: ETHDenomination? = null,
-        convertBtcDenomination: BTCDenomination? = BTCDenomination.SATOSHI
-    ): String {
-        val convertedCoinValue =
-            getConvertedCoinValue(coinValue, convertEthDenomination, convertBtcDenomination)
+    fun getFormattedSelectedCoinValue(coinValue: BigInteger) =
+        getFormattedCoinValue(CryptoValue(currencyState.cryptoCurrency, coinValue))
 
-        return when (currencyState.cryptoCurrency) {
-            CryptoCurrency.BTC -> currencyFormatUtil.formatBtc(convertedCoinValue)
-            CryptoCurrency.ETHER -> currencyFormatUtil.formatEth(convertedCoinValue)
-            CryptoCurrency.BCH -> currencyFormatUtil.formatBch(convertedCoinValue)
-            else -> throw IllegalArgumentException(currencyState.cryptoCurrency.toString() + " not supported.")
-        }
-    }
+    fun getFormattedCoinValue(cryptoValue: CryptoValue) = currencyFormatUtil.format(cryptoValue)
 
     fun getFormattedSelectedCoinValueWithUnit(
         coinValue: BigDecimal,
@@ -445,8 +421,8 @@ class CurrencyFormatManager @Inject constructor(
      *
      * @return btc, mbtc or bits relative to what is set in monetaryUtil
      */
-    fun getTextFromSatoshis(satoshis: Long, decimalSeparator: String): String {
-        var displayAmount = getFormattedSelectedCoinValue(satoshis.toBigDecimal())
+    fun getTextFromSatoshis(satoshis: BigInteger, decimalSeparator: String): String {
+        var displayAmount = getFormattedSelectedCoinValue(satoshis)
         displayAmount = displayAmount.replace(".", decimalSeparator)
         return displayAmount
     }

--- a/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatUtil.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatUtil.kt
@@ -46,29 +46,52 @@ class CurrencyFormatUtil @Inject constructor() {
     @Deprecated("Use format", replaceWith = ReplaceWith("format(CryptoValue.bitcoinCashFromMajor(bch))"))
     fun formatBch(bch: BigDecimal): String = format(CryptoValue.bitcoinCashFromMajor(bch))
 
-    fun formatEth(eth: BigDecimal): String = ethFormat.format(eth.toPositiveDouble()).toWebZero()
+    @Deprecated("Use format", replaceWith = ReplaceWith("format(CryptoValue.etherFromMajor(eth), Precision.Full)"))
+    fun formatEth(eth: BigDecimal): String = format(CryptoValue.etherFromMajor(eth), Precision.Full)
 
-    fun formatWei(wei: Long): String =
-        ethFormat.format(wei.div(ETH_DEC).toPositiveDouble()).toWebZero()
+    @Deprecated("Use format", replaceWith = ReplaceWith("format(CryptoValue.etherFromWei(wei), Precision.Full)"))
+    fun formatWei(wei: Long): String = format(CryptoValue.etherFromWei(wei), Precision.Full)
 
-    fun format(cryptoValue: CryptoValue): String =
-        cryptoValue.currency.decimalFormat().formatWithoutUnit(cryptoValue.toMajorUnit())
+    fun format(cryptoValue: CryptoValue, displayMode: Precision = Precision.Short): String =
+        cryptoValue.currency.decimalFormat(displayMode).formatWithoutUnit(cryptoValue.toMajorUnit())
 
-    fun formatWithUnit(cryptoValue: CryptoValue) =
-        cryptoValue.currency.decimalFormat().formatWithUnit(cryptoValue.toMajorUnit(), cryptoValue.currency.symbol)
+    fun formatWithUnit(cryptoValue: CryptoValue, displayMode: Precision = Precision.Short) =
+        cryptoValue.currency.decimalFormat(displayMode).formatWithUnit(
+            cryptoValue.toMajorUnit(),
+            cryptoValue.currency.symbol
+        )
 
-    @Deprecated("Use formatWithUnit")
-    fun formatBtcWithUnit(btc: BigDecimal) = btcFormat.formatWithUnit(btc, CryptoCurrency.BTC.symbol)
-
-    @Deprecated("Use formatWithUnit")
-    fun formatBchWithUnit(bch: BigDecimal) = bchFormat.formatWithUnit(bch, CryptoCurrency.BCH.symbol)
-
-    fun formatEthWithUnit(eth: BigDecimal) = ethFormat.formatWithUnit(eth, CryptoCurrency.ETHER.symbol)
-
-    @Deprecated("Use formatWithUnit")
-    fun formatEthShortWithUnit(eth: BigDecimal): String {
-        return ethShortFormat.formatWithUnit(eth, CryptoCurrency.ETHER.symbol)
+    enum class Precision {
+        /**
+         * Some currencies will be displayed at a shorter length
+         */
+        Short,
+        /**
+         * Full decimal place precision is used for the display string
+         */
+        Full
     }
+
+    @Deprecated("Use formatWithUnit", replaceWith = ReplaceWith("formatWithUnit(CryptoValue.bitcoinFromMajor(btc))"))
+    fun formatBtcWithUnit(btc: BigDecimal) = formatWithUnit(CryptoValue.bitcoinFromMajor(btc))
+
+    @Deprecated(
+        "Use formatWithUnit",
+        replaceWith = ReplaceWith("formatWithUnit(CryptoValue.bitcoinCashFromMajor(bch))")
+    )
+    fun formatBchWithUnit(bch: BigDecimal) = formatWithUnit(CryptoValue.bitcoinCashFromMajor(bch))
+
+    @Deprecated(
+        "Use formatWithUnit",
+        replaceWith = ReplaceWith("formatWithUnit(CryptoValue.etherFromMajor(eth), Precision.Full)")
+    )
+    fun formatEthWithUnit(eth: BigDecimal) = formatWithUnit(CryptoValue.etherFromMajor(eth), Precision.Full)
+
+    @Deprecated(
+        "Use formatWithUnit",
+        replaceWith = ReplaceWith("formatWithUnit(CryptoValue.etherFromMajor(eth), Precision.Short)")
+    )
+    fun formatEthShortWithUnit(eth: BigDecimal) = formatWithUnit(CryptoValue.etherFromMajor(eth), Precision.Short)
 
     fun formatWeiWithUnit(wei: Long): String {
         val amountFormatted = ethFormat.format(wei.div(ETH_DEC).toPositiveDouble()).toWebZero()
@@ -94,14 +117,16 @@ class CurrencyFormatUtil @Inject constructor() {
 
     companion object {
 
-        private const val BTC_DEC = 1e8
         private const val ETH_DEC = 1e18
     }
 
-    private fun CryptoCurrency.decimalFormat() = when (this) {
+    private fun CryptoCurrency.decimalFormat(displayMode: Precision) = when (this) {
         CryptoCurrency.BTC -> btcFormat
         CryptoCurrency.BCH -> bchFormat
-        CryptoCurrency.ETHER -> ethShortFormat
+        CryptoCurrency.ETHER -> when (displayMode) {
+            Precision.Short -> ethShortFormat
+            Precision.Full -> ethFormat
+        }
     }
 }
 

--- a/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatUtil.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatUtil.kt
@@ -37,13 +37,14 @@ class CurrencyFormatUtil @Inject constructor() {
     fun getFiatSymbol(currencyCode: String, locale: Locale): String =
         Currency.getInstance(currencyCode).getSymbol(locale)
 
-    @Deprecated("Use format")
-    fun formatBtc(btc: BigDecimal): String = btcFormat.format(btc.toPositiveDouble()).toWebZero()
+    @Deprecated("Use format", replaceWith = ReplaceWith("format(CryptoValue.bitcoinFromMajor(btc))"))
+    fun formatBtc(btc: BigDecimal): String = format(CryptoValue.bitcoinFromMajor(btc))
 
-    fun formatSatoshi(satoshi: Long): String =
-        btcFormat.format(satoshi.div(BTC_DEC).toPositiveDouble()).toWebZero()
+    @Deprecated("Use format", replaceWith = ReplaceWith("format(CryptoValue.bitcoinFromSatoshis(satoshi))"))
+    fun formatSatoshi(satoshi: Long): String = format(CryptoValue.bitcoinFromSatoshis(satoshi))
 
-    fun formatBch(bch: BigDecimal): String = formatBtc(bch)
+    @Deprecated("Use format", replaceWith = ReplaceWith("format(CryptoValue.bitcoinCashFromMajor(bch))"))
+    fun formatBch(bch: BigDecimal): String = format(CryptoValue.bitcoinCashFromMajor(bch))
 
     fun formatEth(eth: BigDecimal): String = ethFormat.format(eth.toPositiveDouble()).toWebZero()
 

--- a/core/src/main/java/piuk/blockchain/androidcore/data/exchangerate/ExchangeRateDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/exchangerate/ExchangeRateDataManager.kt
@@ -1,6 +1,7 @@
 package piuk.blockchain.androidcore.data.exchangerate
 
 import info.blockchain.balance.CryptoCurrency
+import info.blockchain.balance.CryptoValue
 import io.reactivex.Observable
 import piuk.blockchain.androidcore.data.exchangerate.datastore.ExchangeRateDataStore
 import piuk.blockchain.androidcore.data.rxjava.RxBus
@@ -31,27 +32,6 @@ class ExchangeRateDataManager @Inject constructor(
 
     fun getLastPrice(cryptoCurrency: CryptoCurrency, currencyName: String) =
         exchangeRateDataStore.getLastPrice(cryptoCurrency, currencyName)
-
-    @Deprecated(
-        "Use getLastPrice",
-        replaceWith = ReplaceWith("getLastPrice(CryptoCurrency.BTC, currencyName)")
-    )
-    fun getLastBtcPrice(currencyName: String) =
-        exchangeRateDataStore.getLastBtcPrice(currencyName)
-
-    @Deprecated(
-        "Use getLastPrice",
-        replaceWith = ReplaceWith("getLastPrice(CryptoCurrency.BCH, currencyName)")
-    )
-    fun getLastBchPrice(currencyName: String) =
-        exchangeRateDataStore.getLastBchPrice(currencyName)
-
-    @Deprecated(
-        "Use getLastPrice",
-        replaceWith = ReplaceWith("getLastPrice(CryptoCurrency.ETHER, currencyName)")
-    )
-    fun getLastEthPrice(currencyName: String) =
-        exchangeRateDataStore.getLastEthPrice(currencyName)
 
     fun getCurrencyLabels() = exchangeRateDataStore.getCurrencyLabels()
 
@@ -137,31 +117,38 @@ class ExchangeRateDataManager @Inject constructor(
     }
 
     fun getBtcFromFiat(fiatAmount: BigDecimal, fiatUnit: String): BigDecimal {
-        return fiatAmount.divide(getLastBtcPrice(fiatUnit).toBigDecimal(), 8, RoundingMode.HALF_UP)
+        return fiatAmount.divide(getLastPrice(CryptoCurrency.BTC, fiatUnit).toBigDecimal(), 8, RoundingMode.HALF_UP)
     }
 
     fun getBchFromFiat(fiatAmount: BigDecimal, fiatUnit: String): BigDecimal {
-        return fiatAmount.divide(getLastBchPrice(fiatUnit).toBigDecimal(), 8, RoundingMode.HALF_UP)
+        return fiatAmount.divide(getLastPrice(CryptoCurrency.BCH, fiatUnit).toBigDecimal(), 8, RoundingMode.HALF_UP)
     }
 
     fun getEthFromFiat(fiatAmount: BigDecimal, fiatUnit: String): BigDecimal {
-        return fiatAmount.divide(getLastEthPrice(fiatUnit).toBigDecimal(), 8, RoundingMode.HALF_UP)
+        return fiatAmount.divide(getLastPrice(CryptoCurrency.ETHER, fiatUnit).toBigDecimal(), 8, RoundingMode.HALF_UP)
     }
 
+    @Deprecated("Use CryptoValue.toFiat")
     fun getFiatFromBtc(btc: BigDecimal, fiatUnit: String): BigDecimal {
-        return getLastBtcPrice(fiatUnit).toBigDecimal().multiply(btc)
+        return getLastPrice(CryptoCurrency.BTC, fiatUnit).toBigDecimal() * btc
     }
 
+    @Deprecated("Use CryptoValue.toFiat")
     fun getFiatFromBch(bch: BigDecimal, fiatUnit: String): BigDecimal {
-        return getLastBchPrice(fiatUnit).toBigDecimal().multiply(bch)
+        return getLastPrice(CryptoCurrency.BCH, fiatUnit).toBigDecimal() * bch
     }
 
+    @Deprecated("Use CryptoValue.toFiat")
     fun getFiatFromEth(eth: BigDecimal, fiatUnit: String): BigDecimal {
-        return getLastEthPrice(fiatUnit).toBigDecimal().multiply(eth)
+        return getLastPrice(CryptoCurrency.ETHER, fiatUnit).toBigDecimal() * eth
     }
 
     companion object {
         internal val SATOSHIS_PER_BITCOIN = BigDecimal.valueOf(100_000_000L)
         internal val WEI_PER_ETHER = BigDecimal.valueOf(1e18)
     }
+}
+
+fun CryptoValue.toFiat(exchangeRateDataManager: ExchangeRateDataManager, fiatUnit: String): BigDecimal {
+    return exchangeRateDataManager.getLastPrice(currency, fiatUnit).toBigDecimal() * toMajorUnit()
 }

--- a/core/src/main/java/piuk/blockchain/androidcore/data/exchangerate/datastore/ExchangeRateDataStore.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/exchangerate/datastore/ExchangeRateDataStore.kt
@@ -46,27 +46,6 @@ class ExchangeRateDataStore @Inject constructor(
 
     fun getCurrencyLabels(): Array<String> = btcTickerData!!.keys.toTypedArray()
 
-    @Deprecated(
-        "Use getLastPrice",
-        replaceWith = ReplaceWith("getLastPrice(CryptoCurrency.BTC, currencyName)")
-    )
-    fun getLastBtcPrice(currencyName: String) =
-        getLastPrice(CryptoCurrency.BTC, currencyName.toUpperCase())
-
-    @Deprecated(
-        "Use getLastPrice",
-        replaceWith = ReplaceWith("getLastPrice(CryptoCurrency.BCH, currencyName)")
-    )
-    fun getLastBchPrice(currencyName: String) =
-        getLastPrice(CryptoCurrency.BCH, currencyName.toUpperCase())
-
-    @Deprecated(
-        "Use getLastPrice",
-        replaceWith = ReplaceWith("getLastPrice(CryptoCurrency.ETHER, currencyName)")
-    )
-    fun getLastEthPrice(currencyName: String) =
-        getLastPrice(CryptoCurrency.ETHER, currencyName.toUpperCase())
-
     fun getLastPrice(cryptoCurrency: CryptoCurrency, currencyName: String): Double {
         val prefsKey: String
         val tickerData: Map<String, PriceDatum>?

--- a/core/src/test/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManagerTest.kt
+++ b/core/src/test/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManagerTest.kt
@@ -1,13 +1,15 @@
 package piuk.blockchain.androidcore.data.currency
 
-import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.whenever
 import info.blockchain.balance.CryptoCurrency
+import info.blockchain.balance.CryptoValue
 import org.amshove.kluent.mock
 import org.junit.Before
 import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager
 import piuk.blockchain.androidcore.utils.PrefsUtil
 import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.Locale
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -230,14 +232,25 @@ class CurrencyFormatManagerTest {
     }
 
     @Test
-    fun `getFormattedSelectedCoinValue BTC default satoshi denomination`() {
+    fun `getFormattedSelectedCoinValue BTC`() {
         // Arrange
         whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.BTC)
-        whenever(currencyFormatUtil.formatBtc(any())).thenReturn("something")
+        whenever(currencyFormatUtil.format(eq(CryptoValue.bitcoinFromSatoshis(1L)))).thenReturn("one Satoshi")
 
         // Act
         // Assert
-        assertEquals("something", subject.getFormattedSelectedCoinValue(BigDecimal.valueOf(1L)))
+        assertEquals("one Satoshi", subject.getFormattedSelectedCoinValue(BigInteger.valueOf(1L)))
+    }
+
+    @Test
+    fun `getFormattedSelectedCoinValue ETH`() {
+        // Arrange
+        whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.ETHER)
+        whenever(currencyFormatUtil.format(eq(CryptoValue.etherFromWei(2L)))).thenReturn("two Wei")
+
+        // Act
+        // Assert
+        assertEquals("two Wei", subject.getFormattedSelectedCoinValue(BigInteger.valueOf(2L)))
     }
 
     // endregion

--- a/core/src/test/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManagerTest.kt
+++ b/core/src/test/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManagerTest.kt
@@ -235,22 +235,64 @@ class CurrencyFormatManagerTest {
     fun `getFormattedSelectedCoinValue BTC`() {
         // Arrange
         whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.BTC)
-        whenever(currencyFormatUtil.format(eq(CryptoValue.bitcoinFromSatoshis(1L)))).thenReturn("one Satoshi")
+        whenever(
+            currencyFormatUtil.format(
+                eq(CryptoValue.bitcoinFromSatoshis(1L)),
+                eq(CurrencyFormatUtil.Precision.Full)
+            )
+        ).thenReturn("one")
 
         // Act
         // Assert
-        assertEquals("one Satoshi", subject.getFormattedSelectedCoinValue(BigInteger.valueOf(1L)))
+        assertEquals("one", subject.getFormattedSelectedCoinValue(BigInteger.valueOf(1L)))
     }
 
     @Test
     fun `getFormattedSelectedCoinValue ETH`() {
         // Arrange
         whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.ETHER)
-        whenever(currencyFormatUtil.format(eq(CryptoValue.etherFromWei(2L)))).thenReturn("two Wei")
+        whenever(
+            currencyFormatUtil.format(
+                eq(CryptoValue.etherFromWei(2L)),
+                eq(CurrencyFormatUtil.Precision.Full)
+            )
+        ).thenReturn("two")
 
         // Act
         // Assert
-        assertEquals("two Wei", subject.getFormattedSelectedCoinValue(BigInteger.valueOf(2L)))
+        assertEquals("two", subject.getFormattedSelectedCoinValue(BigInteger.valueOf(2L)))
+    }
+
+    @Test
+    fun `getFormattedSelectedCoinValueWithUnit BTC`() {
+        // Arrange
+        whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.BCH)
+        whenever(
+            currencyFormatUtil.formatWithUnit(
+                eq(CryptoValue.bitcoinCashFromSatoshis(2L)),
+                eq(CurrencyFormatUtil.Precision.Full)
+            )
+        ).thenReturn("two BCH Satoshi")
+
+        // Act
+        // Assert
+        assertEquals("two BCH Satoshi", subject.getFormattedSelectedCoinValueWithUnit(BigInteger.valueOf(2L)))
+    }
+
+    @Test
+    fun `getFormattedSelectedCoinValueWithUnit ETH`() {
+        // Arrange
+        whenever(currencyState.cryptoCurrency).thenReturn(CryptoCurrency.ETHER)
+        whenever(
+            currencyFormatUtil.formatWithUnit(
+                eq(CryptoValue.etherFromWei(2L)),
+                eq(CurrencyFormatUtil.Precision.Full)
+            )
+        ).thenReturn("two Wei")
+
+        // Act
+        // Assert
+        assertEquals("two Wei", subject.getFormattedSelectedCoinValueWithUnit(BigInteger.valueOf(2L)))
     }
 
     // endregion

--- a/core/src/test/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatUtilTest.kt
+++ b/core/src/test/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatUtilTest.kt
@@ -141,6 +141,24 @@ class CurrencyFormatUtilTest {
     }
 
     @Test
+    fun `formatWithUnit ETH with tiny fractions - full precision`() {
+        val formatWithUnit =
+            { wei: Long -> subject.formatWithUnit(CryptoValue.etherFromWei(wei), CurrencyFormatUtil.Precision.Full) }
+        formatWithUnit(1L) `should equal` "0.000000000000000001 ETH"
+        formatWithUnit(10L) `should equal` "0.00000000000000001 ETH"
+        formatWithUnit(100L) `should equal` "0.0000000000000001 ETH"
+        formatWithUnit(1_000L) `should equal` "0.000000000000001 ETH"
+        formatWithUnit(10_000L) `should equal` "0.00000000000001 ETH"
+        formatWithUnit(100_000L) `should equal` "0.0000000000001 ETH"
+        formatWithUnit(1_000_000L) `should equal` "0.000000000001 ETH"
+        formatWithUnit(10_000_000L) `should equal` "0.00000000001 ETH"
+        formatWithUnit(100_000_000L) `should equal` "0.0000000001 ETH"
+        formatWithUnit(1_000_000_000L) `should equal` "0.000000001 ETH"
+        formatWithUnit(10_000_000_000L) `should equal` "0.00000001 ETH"
+        formatWithUnit(100_000_000_000L) `should equal` "0.0000001 ETH"
+    }
+
+    @Test
     fun `formatWithUnit ETH fractions`() {
         subject.formatWithUnit(CryptoValue.etherFromWei(10_000_000_000L)) `should equal` "0.00000001 ETH"
         subject.formatWithUnit(CryptoValue.etherFromWei(100_000_000_000L)) `should equal` "0.0000001 ETH"

--- a/core/src/test/java/piuk/blockchain/androidcore/data/exchangerate/ExchangeRateDataManagerTest.kt
+++ b/core/src/test/java/piuk/blockchain/androidcore/data/exchangerate/ExchangeRateDataManagerTest.kt
@@ -2,7 +2,10 @@ package piuk.blockchain.androidcore.data.exchangerate
 
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.whenever
+import info.blockchain.balance.CryptoCurrency
+import info.blockchain.balance.CryptoValue
 import io.reactivex.Observable
+import org.amshove.kluent.`should equal`
 import org.amshove.kluent.mock
 import org.junit.Before
 import org.web3j.utils.Convert
@@ -32,7 +35,7 @@ class ExchangeRateDataManagerTest {
         // Arrange
         val exchangeRate = 5000.0
         val satoshis = 10L
-        whenever(exchangeRateDataStore.getLastBtcPrice("USD")).thenReturn(exchangeRate)
+        whenever(exchangeRateDataStore.getLastPrice(CryptoCurrency.BTC, "USD")).thenReturn(exchangeRate)
 
         // Act
         val result = subject.getFiatFromBtc(BigDecimal.valueOf(satoshis), "USD")
@@ -50,7 +53,7 @@ class ExchangeRateDataManagerTest {
         // Arrange
         val exchangeRate = 5000.0
         val satoshis = 10L
-        whenever(exchangeRateDataStore.getLastEthPrice("USD")).thenReturn(exchangeRate)
+        whenever(exchangeRateDataStore.getLastPrice(CryptoCurrency.ETHER, "USD")).thenReturn(exchangeRate)
 
         // Act
         val result = subject.getFiatFromEth(BigDecimal.valueOf(satoshis), "USD")
@@ -68,7 +71,7 @@ class ExchangeRateDataManagerTest {
         // Arrange
         val exchangeRate = 5000.0
         val satoshis = 10L
-        whenever(exchangeRateDataStore.getLastBchPrice("USD")).thenReturn(exchangeRate)
+        whenever(exchangeRateDataStore.getLastPrice(CryptoCurrency.BCH, "USD")).thenReturn(exchangeRate)
 
         // Act
         val result = subject.getFiatFromBch(BigDecimal.valueOf(satoshis), "USD")
@@ -84,7 +87,7 @@ class ExchangeRateDataManagerTest {
     fun getBtcFromFiat() {
 
         // Arrange
-        whenever(exchangeRateDataStore.getLastBtcPrice("USD")).thenReturn(8100.37)
+        whenever(exchangeRateDataStore.getLastPrice(CryptoCurrency.BTC, "USD")).thenReturn(8100.37)
 
         // Act
         val result = subject.getBtcFromFiat(BigDecimal.valueOf(4050.18), "USD")
@@ -97,7 +100,7 @@ class ExchangeRateDataManagerTest {
     fun getBchFromFiat() {
 
         // Arrange
-        whenever(exchangeRateDataStore.getLastBchPrice("USD")).thenReturn(8100.37)
+        whenever(exchangeRateDataStore.getLastPrice(CryptoCurrency.BCH, "USD")).thenReturn(8100.37)
 
         // Act
         val result = subject.getBchFromFiat(BigDecimal.valueOf(4050.18), "USD")
@@ -110,7 +113,7 @@ class ExchangeRateDataManagerTest {
     fun getEthFromFiat() {
 
         // Arrange
-        whenever(exchangeRateDataStore.getLastEthPrice("USD")).thenReturn(8100.37)
+        whenever(exchangeRateDataStore.getLastPrice(CryptoCurrency.ETHER, "USD")).thenReturn(8100.37)
 
         // Act
         val result = subject.getEthFromFiat(BigDecimal.valueOf(4050.18), "USD")
@@ -173,5 +176,37 @@ class ExchangeRateDataManagerTest {
             .assertValue { result -> result.compareTo(BigDecimal.valueOf(4050.185)) == 0 }
         subject.getBchHistoricPrice((1e8.toLong() / 3), "", 0L).test()
             .assertValue { result -> result.compareTo(BigDecimal.valueOf(2700.1233063321)) == 0 }
+    }
+
+    @Test
+    fun `BTC toFiat`() {
+        givenExchangeRate(CryptoCurrency.BTC, "USD", 5000.0)
+
+        CryptoValue.bitcoinFromSatoshis(1_000_000L).toFiat(subject, "USD")
+            .compareTo(BigDecimal.valueOf(50)) `should equal` 0
+    }
+
+    @Test
+    fun `BCH toFiat`() {
+        givenExchangeRate(CryptoCurrency.BCH, "USD", 1000.0)
+
+        CryptoValue.bitcoinCashFromSatoshis(10_000_000L).toFiat(subject, "USD")
+            .compareTo(BigDecimal.valueOf(100)) `should equal` 0
+    }
+
+    @Test
+    fun `ETH toFiat`() {
+        givenExchangeRate(CryptoCurrency.ETHER, "USD", 1000.0)
+
+        CryptoValue.etherFromMajor(2).toFiat(subject, "USD")
+            .compareTo(BigDecimal.valueOf(2000)) `should equal` 0
+    }
+
+    private fun givenExchangeRate(
+        cryptoCurrency: CryptoCurrency,
+        currencyName: String,
+        exchangeRate: Double
+    ) {
+        whenever(exchangeRateDataStore.getLastPrice(cryptoCurrency, currencyName)).thenReturn(exchangeRate)
     }
 }


### PR DESCRIPTION
- Replace repeated price and format code with code that uses CryptoCurrency enum. 
- Deprecate some more methods that do not take a CryptoCurrency or CryptoValue.