### PR TITLE
fix(Exchange Rates): AND-1271 Remove exchange rates from details page…

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/buysell/createorder/BuySellBuildOrderPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/buysell/createorder/BuySellBuildOrderPresenter.kt
@@ -486,7 +486,7 @@ class BuySellBuildOrderPresenter @Inject constructor(
                 ).flatMap { (trader, inMedium) ->
                     val currency = if (initialLoad) getDefaultCurrency(trader.defaultCurrency) else selectedCurrency
 
-                    getExchangeRate(token, -1.0, currency)
+                    getExchangeRate(token, if (isSell) -1.0 else 1.0, currency)
                         .toObservable()
                         .doOnNext {
                             maximumInCardAmount = trader.level?.limits?.card?.inX?.daily ?: 0.0
@@ -665,7 +665,7 @@ class BuySellBuildOrderPresenter @Inject constructor(
             .doOnSuccess {
                 val valueWithSymbol =
                     currencyFormatManager.getFormattedFiatValueWithSymbol(
-                        it.quoteAmount,
+                        it.quoteAmount.absoluteValue,
                         it.quoteCurrency,
                         view.locale
                     )

--- a/app/src/main/java/piuk/blockchain/android/ui/buysell/details/models/DetailsModels.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/buysell/details/models/DetailsModels.kt
@@ -18,7 +18,6 @@ data class BuySellDetailsModel(
     val tradeIdDisplay: String,
     val tradeId: Int,
     val currencyReceivedTitle: String,
-    val exchangeRate: String,
     val amountSent: String,
     val paymentFee: String,
     val totalCost: String

--- a/app/src/main/java/piuk/blockchain/android/ui/buysell/details/trade/CoinifyTransactionDetailActivity.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/buysell/details/trade/CoinifyTransactionDetailActivity.kt
@@ -25,7 +25,6 @@ import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_v
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_bank_disclaimer as textViewBankDisclaimer
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_currency_received_text as textViewCurrencyReceivedDetail
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_currency_received_title as textViewCurrencyReceivedTitle
-import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_exchange_rate_text as textViewExchangeRate
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_order_amount as textViewOrderAmountHeader
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_payment_fee_text as textViewPaymentFeeDetail
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_payment_fee_title as textViewPaymentFeeTitle
@@ -33,7 +32,6 @@ import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_v
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_total_title as textViewTotalTitle
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_trade_id_text as textViewTradeId
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.text_view_transaction_date as textViewDateHeader
-import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.view_divider_bank_disclaimer as dividerBankDisclaimer
 import kotlinx.android.synthetic.main.activity_coinify_transaction_detail.view_divider_total as dividerTotal
 
 class CoinifyTransactionDetailActivity :
@@ -50,10 +48,7 @@ class CoinifyTransactionDetailActivity :
     }
 
     private val bankSellInProgressViewsToShow by unsafeLazy {
-        listOf<View>(
-            dividerBankDisclaimer,
-            textViewBankDisclaimer
-        )
+        listOf<View>(textViewBankDisclaimer)
     }
     private val bankSellInProgressViewsToHide by unsafeLazy {
         listOf<View>(
@@ -89,7 +84,6 @@ class CoinifyTransactionDetailActivity :
         textViewTradeId.text = model.tradeIdDisplay
         textViewCurrencyReceivedTitle.text = model.currencyReceivedTitle
         textViewCurrencyReceivedDetail.text = model.detailAmount
-        textViewExchangeRate.text = model.exchangeRate
         textViewAmountDetail.text = model.amountSent
         textViewPaymentFeeDetail.text = model.paymentFee
         textViewTotalDetail.text = model.totalCost

--- a/app/src/main/java/piuk/blockchain/android/ui/buysell/overview/CoinifyOverviewPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/buysell/overview/CoinifyOverviewPresenter.kt
@@ -433,7 +433,7 @@ class CoinifyOverviewPresenter @Inject constructor(
         val displayString = if (coinifyTrade.isSellTransaction()) {
             "-${coinifyTrade.inAmount} ${coinifyTrade.inCurrency.capitalize()}"
         } else {
-            val amount = coinifyTrade.outAmount ?: coinifyTrade.outAmountExpected
+            val amount = coinifyTrade.transferOut.receiveAmount
             "+$amount ${coinifyTrade.outCurrency.capitalize()}"
         }
 
@@ -476,6 +476,7 @@ class CoinifyOverviewPresenter @Inject constructor(
         val sent = coinifyTrade.transferIn.receiveAmount
         val sentWithFee = coinifyTrade.transferIn.sendAmount
         val received = coinifyTrade.transferOut.sendAmount
+        val receivedWithFee = coinifyTrade.transferOut.receiveAmount
         val sellPaymentFee = coinifyTrade.transferOut.getFee()
         val paymentFee = coinifyTrade.transferIn.getFee().toBigDecimal()
             .setScale(8, RoundingMode.HALF_UP)
@@ -489,18 +490,14 @@ class CoinifyOverviewPresenter @Inject constructor(
         val headlineAmount: String
         val detailAmount: String
         val paymentFeeString: String
-        val exchangeRateString: String
         val receiveTitleString: String
         val amountString: String
         val totalString: String
 
         if (!coinifyTrade.isSellTransaction()) {
             // Crypto out (from Coinify's perspective)
-            headlineAmount = "$received $receiveCurrency"
-            detailAmount = "$received $receiveCurrency"
-            // Exchange rate (always in fiat)
-            val exchangeRate = sent / received
-            exchangeRateString = formatFiatWithSymbol(exchangeRate, sendCurrency, view.locale)
+            headlineAmount = "$receivedWithFee $receiveCurrency"
+            detailAmount = "$receivedWithFee $receiveCurrency"
             // Fiat in
             amountString = formatFiatWithSymbol(sent, sendCurrency, view.locale)
             paymentFeeString =
@@ -518,9 +515,6 @@ class CoinifyOverviewPresenter @Inject constructor(
             headlineAmount =
                 formatFiatWithSymbol(received - sellPaymentFee, receiveCurrency, view.locale)
             detailAmount = "$sent $sendCurrency"
-            // Exchange rate (always in fiat)
-            val exchangeRate = received / sent
-            exchangeRateString = formatFiatWithSymbol(exchangeRate, receiveCurrency, view.locale)
             // Crypto in
             paymentFeeString = "Not rendered"
             totalString = "Not rendered"
@@ -544,7 +538,6 @@ class CoinifyOverviewPresenter @Inject constructor(
             "#${coinifyTrade.id}",
             coinifyTrade.id,
             receiveTitleString,
-            exchangeRateString,
             amountString,
             paymentFeeString,
             totalString

--- a/app/src/main/res/layout/activity_coinify_transaction_detail.xml
+++ b/app/src/main/res/layout/activity_coinify_transaction_detail.xml
@@ -116,26 +116,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/text_view_currency_received_title" />
 
-            <!-- Exchange Rate -->
-
-            <TextView
-                android:id="@+id/text_view_exchange_rate_title"
-                style="@style/BuySellDetailTitle"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/buy_sell_detail_exchange_rate"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/view_divider_currency_received" />
-
-            <TextView
-                android:id="@+id/text_view_exchange_rate_text"
-                style="@style/BuySellDetailMessage"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/view_divider_currency_received"
-                tools:text="8,654.04 GBP" />
-
             <!-- Amount -->
 
             <TextView
@@ -145,7 +125,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/buy_sell_detail_amount"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_exchange_rate_title" />
+                app:layout_constraintTop_toBottomOf="@+id/view_divider_currency_received" />
 
             <TextView
                 android:id="@+id/text_view_amount_text"
@@ -153,7 +133,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/text_view_exchange_rate_text"
+                app:layout_constraintTop_toBottomOf="@+id/view_divider_currency_received"
                 tools:text="200.00 GBP" />
 
             <!-- Payment Fee -->
@@ -231,14 +211,6 @@
 
             <!-- Sell in Progress Specific -->
 
-            <View
-                android:id="@+id/view_divider_bank_disclaimer"
-                style="@style/BuySellDetailDivider"
-                android:visibility="gone"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/text_view_exchange_rate_title" />
-
             <TextView
                 android:id="@+id/text_view_bank_disclaimer"
                 android:layout_width="0dp"
@@ -251,7 +223,7 @@
                 android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/view_divider_bank_disclaimer" />
+                app:layout_constraintTop_toBottomOf="@id/view_divider_total" />
 
 
         </android.support.constraint.ConstraintLayout>

--- a/app/src/test/java/piuk/blockchain/android/ui/buysell/details/trade/CoinifyTransactionDetailPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/buysell/details/trade/CoinifyTransactionDetailPresenterTest.kt
@@ -58,7 +58,6 @@ class CoinifyTransactionDetailPresenterTest {
             tradeIdDisplay = "",
             tradeId = tradeId,
             currencyReceivedTitle = "",
-            exchangeRate = "",
             amountSent = "",
             paymentFee = "",
             totalCost = ""
@@ -112,7 +111,6 @@ class CoinifyTransactionDetailPresenterTest {
             tradeIdDisplay = "",
             tradeId = tradeId,
             currencyReceivedTitle = "",
-            exchangeRate = "",
             amountSent = "",
             paymentFee = "",
             totalCost = ""


### PR DESCRIPTION
…s, fix quote amount depending on trade direction

After much scratching my head, there's a small discrepancy in the exchange rate from Coinify vs the exchange rate calculated after the fact. Web doesn't display the exchange rate on transaction details pages, and now, nor do we.