### PR TITLE
feat(Non-Spendable): AND-1217 Non-Spendable Chart UI

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/dashboard/PieChartsState.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/dashboard/PieChartsState.kt
@@ -1,0 +1,29 @@
+package piuk.blockchain.android.ui.dashboard
+
+import info.blockchain.balance.FiatValue
+import java.util.Locale
+
+sealed class PieChartsState {
+
+    data class DataPoint(
+        val fiatValue: FiatValue,
+        val cryptoValueString: String
+    ) {
+        val isZero: Boolean = fiatValue.isZero
+        val fiatValueString: String = fiatValue.toStringWithSymbol(Locale.getDefault())
+    }
+
+    data class Data(
+        val bitcoin: DataPoint,
+        val bitcoinWatchOnly: DataPoint? = null,
+        val ether: DataPoint,
+        val bitcoinCash: DataPoint
+    ) : PieChartsState() {
+        val isZero: Boolean = bitcoin.isZero && bitcoinCash.isZero && ether.isZero
+        private val totalValue: FiatValue = bitcoin.fiatValue + bitcoinCash.fiatValue + ether.fiatValue
+        val totalValueString: String = totalValue.toStringWithSymbol(Locale.getDefault())
+    }
+
+    object Loading : PieChartsState()
+    object Error : PieChartsState()
+}

--- a/app/src/main/res/drawable/rounded_non_spendable_button.xml
+++ b/app/src/main/res/drawable/rounded_non_spendable_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <solid android:color="@color/non_spendable_button_background" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/non_spendable_button_border" />
+
+    <corners android:radius="4dp" />
+</shape>

--- a/app/src/main/res/layout/item_pie_chart.xml
+++ b/app/src/main/res/layout/item_pie_chart.xml
@@ -76,19 +76,19 @@
 
             <TextView
                 android:id="@+id/textview_title_bitcoin"
-                style="@style/DashboardCoinTitle"
+                style="@style/DashboardCoinTitle.LayoutMatchParentWidth"
                 android:text="@string/bitcoin" />
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/textview_value_bitcoin"
-                style="@style/DashboardCoinAmounts"
+                style="@style/DashboardCoinAmounts.LayoutMatchParentWidth"
                 app:autoSizePresetSizes="@array/autosize_text_sizes"
                 app:autoSizeTextType="uniform"
                 tools:text="$17,000.23" />
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/textview_amount_bitcoin"
-                style="@style/DashboardCoinAmounts"
+                style="@style/DashboardCoinAmounts.LayoutMatchParentWidth"
                 app:autoSizePresetSizes="@array/autosize_text_sizes"
                 app:autoSizeTextType="uniform"
                 tools:text="1.2352003 BTC" />
@@ -108,19 +108,19 @@
 
             <TextView
                 android:id="@+id/textview_title_ether"
-                style="@style/DashboardCoinTitle"
+                style="@style/DashboardCoinTitle.LayoutMatchParentWidth"
                 android:text="@string/ether" />
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/textview_value_ether"
-                style="@style/DashboardCoinAmounts"
+                style="@style/DashboardCoinAmounts.LayoutMatchParentWidth"
                 app:autoSizePresetSizes="@array/autosize_text_sizes"
                 app:autoSizeTextType="uniform"
                 tools:text="$1,103.01" />
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/textview_amount_ether"
-                style="@style/DashboardCoinAmounts"
+                style="@style/DashboardCoinAmounts.LayoutMatchParentWidth"
                 app:autoSizePresetSizes="@array/autosize_text_sizes"
                 app:autoSizeTextType="uniform"
                 tools:text="1.73472884 ETH" />
@@ -140,24 +140,26 @@
 
             <TextView
                 android:id="@+id/textview_title_bitcoin_cash"
-                style="@style/DashboardCoinTitle"
+                style="@style/DashboardCoinTitle.LayoutMatchParentWidth"
                 android:text="@string/bitcoin_cash" />
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/textview_value_bitcoin_cash"
-                style="@style/DashboardCoinAmounts"
+                style="@style/DashboardCoinAmounts.LayoutMatchParentWidth"
                 app:autoSizePresetSizes="@array/autosize_text_sizes"
                 app:autoSizeTextType="uniform"
                 tools:text="$3,301.35" />
 
             <android.support.v7.widget.AppCompatTextView
                 android:id="@+id/textview_amount_bitcoin_cash"
-                style="@style/DashboardCoinAmounts"
+                style="@style/DashboardCoinAmounts.LayoutMatchParentWidth"
                 app:autoSizePresetSizes="@array/autosize_text_sizes"
                 app:autoSizeTextType="uniform"
                 tools:text="0.6352324 BCH" />
 
         </LinearLayout>
+
+        <include layout="@layout/item_pie_chart_bitcoin_unspendable"/>
 
         <ProgressBar
             android:id="@+id/progress_bar"

--- a/app/src/main/res/layout/item_pie_chart_bitcoin_unspendable.xml
+++ b/app/src/main/res/layout/item_pie_chart_bitcoin_unspendable.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/non_spendable_pane"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="16dp"
+    android:orientation="vertical"
+    android:visibility="gone"
+    app:layout_constraintEnd_toEndOf="@+id/linear_layout_bitcoin_cash"
+    app:layout_constraintStart_toStartOf="@+id/linear_layout_bitcoin"
+    app:layout_constraintTop_toBottomOf="@+id/linear_layout_bitcoin"
+    tools:showIn="@layout/item_pie_chart"
+    tools:visibility="visible">
+
+    <View
+        android:id="@+id/view_non_spendable_separator"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="#FFDDDDDD"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/textView"
+        style="@style/DashboardCoinTitle.Small"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/bitcoin"
+        app:layout_constraintBaseline_toBaselineOf="@+id/textview_bitcoin_non_spendable_toggle" />
+
+    <TextView
+        android:id="@+id/textview_bitcoin_non_spendable_toggle"
+        style="@style/DashboardCoinAmounts.NonSpendable"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/textView"
+        app:layout_constraintTop_toBottomOf="@+id/view_non_spendable_separator"
+        tools:text="50.12345678 BTC Non-Spendable" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -784,6 +784,7 @@
     <string name="dashboard_price_charts">Price charts</string>
     <string name="dashboard_see_charts">See charts</string>
     <string name="dashboard_price">%1$s price</string>
+    <string name="dashboard_non_spendable_value">%1$s Non-Spendable</string>
 
     <!-- ONBOARDING -->
     <string name="onboarding_cta">Get Started</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -372,21 +372,39 @@
     </style>
 
     <style name="DashboardCoinTitle">
-        <item name="android:layout_width">match_parent</item>
-        <item name="android:layout_height">wrap_content</item>
         <item name="android:textColor">@color/primary_gray_dark</item>
         <item name="android:textSize">14sp</item>
         <item name="android:fontFamily">@font/montserrat</item>
     </style>
 
-    <style name="DashboardCoinAmounts">
-        <item name="android:layout_width">wrap_content</item>
+    <style name="DashboardCoinTitle.LayoutMatchParentWidth">
+        <item name="android:layout_width">match_parent</item>
         <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="DashboardCoinTitle.Small">
+        <item name="android:textSize">12sp</item>
+    </style>
+
+    <style name="DashboardCoinAmounts">
         <item name="android:textColor">@color/primary_gray_dark</item>
         <item name="android:textSize">12sp</item>
         <item name="android:ellipsize">end</item>
         <item name="android:maxLines">1</item>
         <item name="android:fontFamily">@font/montserrat</item>
+    </style>
+
+    <style name="DashboardCoinAmounts.LayoutMatchParentWidth">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+    </style>
+
+    <style name="DashboardCoinAmounts.NonSpendable">
+        <item name="android:background">@drawable/rounded_non_spendable_button</item>
+        <item name="android:paddingBottom">5dp</item>
+        <item name="android:paddingEnd">10dp</item>
+        <item name="android:paddingStart">10dp</item>
+        <item name="android:paddingTop">5dp</item>
     </style>
 
     <style name="ToolbarTitleTextAppearance" parent="TextAppearance.Widget.AppCompat.Toolbar.Title">

--- a/app/src/test/java/piuk/blockchain/android/ui/dashboard/DashboardPresenterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/dashboard/DashboardPresenterTest.kt
@@ -586,6 +586,9 @@ class DashboardPresenterTest {
             currency == CryptoCurrency.BTC && this is AccountKey.EntireWallet
         })
         verify(transactionListDataManager).balance(argThat {
+            currency == CryptoCurrency.BTC && this is AccountKey.WatchOnly
+        })
+        verify(transactionListDataManager).balance(argThat {
             currency == CryptoCurrency.BCH && this is AccountKey.EntireWallet
         })
     }

--- a/coreui/src/main/java/piuk/blockchain/androidcoreui/utils/extensions/ViewExtensions.kt
+++ b/coreui/src/main/java/piuk/blockchain/androidcoreui/utils/extensions/ViewExtensions.kt
@@ -42,10 +42,19 @@ fun View?.gone() {
  * @param func If true, the visibility of the [View] will be set to [View.GONE], else [View.VISIBLE]
  */
 fun View?.goneIf(func: () -> Boolean) {
-    if (func()) {
-        if (this != null) visibility = View.GONE
-    } else {
-        if (this != null) visibility = View.VISIBLE
+    if (this != null) {
+        visibility = if (func()) View.GONE else View.VISIBLE
+    }
+}
+
+/**
+ * Sets the visibility of a [View] to [View.GONE] depending on a value
+ *
+ * @param value If true, the visibility of the [View] will be set to [View.GONE], else [View.VISIBLE]
+ */
+fun View?.goneIf(value: Boolean) {
+    if (this != null) {
+        visibility = if (value) View.GONE else View.VISIBLE
     }
 }
 
@@ -55,10 +64,19 @@ fun View?.goneIf(func: () -> Boolean) {
  * @param func If true, the visibility of the [View] will be set to [View.INVISIBLE], else [View.VISIBLE]
  */
 fun View?.invisibleIf(func: () -> Boolean) {
-    if (func()) {
-        if (this != null) visibility = View.INVISIBLE
-    } else {
-        if (this != null) visibility = View.VISIBLE
+    if (this != null) {
+        visibility = if (func()) View.INVISIBLE else View.VISIBLE
+    }
+}
+
+/**
+ * Sets the visibility of a [View] to [View.INVISIBLE] depending on a value
+ *
+ * @param value If true, the visibility of the [View] will be set to [View.INVISIBLE], else [View.VISIBLE]
+ */
+fun View?.invisibleIf(value: Boolean) {
+    if (this != null) {
+        visibility = if (value) View.INVISIBLE else View.VISIBLE
     }
 }
 

--- a/coreui/src/main/res/values/colors.xml
+++ b/coreui/src/main/res/values/colors.xml
@@ -64,4 +64,9 @@
     <!-- Official Cryptocurrency colours -->
     <color name="color_bitcoin_logo">#FF9900</color>
 
+
+    <!-- Non-Spendable colours -->
+    <color name="non_spendable_button_background">#FFEEEEEE</color>
+    <color name="non_spendable_button_border">#FFCFCFCF</color>
+
 </resources>

--- a/coreui/src/test/java/piuk/blockchain/androidcoreui/utils/extensions/GoneIfTest.kt
+++ b/coreui/src/test/java/piuk/blockchain/androidcoreui/utils/extensions/GoneIfTest.kt
@@ -1,0 +1,57 @@
+package piuk.blockchain.androidcoreui.utils.extensions
+
+import android.view.View
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.verify
+import org.amshove.kluent.`it returns`
+import org.junit.Test
+
+class GoneIfTest {
+
+    @Test
+    fun `when function evaluates to true, the view is set to gone`() {
+        mock<View>()
+            .apply {
+                goneIf { true }
+                verify(this).visibility = View.GONE
+            }
+    }
+
+    @Test
+    fun `when function evaluates to false, the view is set to visible`() {
+        mock<View>()
+            .apply {
+                goneIf { false }
+                verify(this).visibility = View.VISIBLE
+            }
+    }
+
+    @Test
+    fun `when view is null, the function does not evaluate`() {
+        mock<() -> Boolean> {
+            onGeneric { invoke() } `it returns` true
+        }.apply {
+            (null as View?).goneIf(this)
+            verify(this, never()).invoke()
+        }
+    }
+
+    @Test
+    fun `when supplied true, the view is set to gone`() {
+        mock<View>()
+            .apply {
+                goneIf(true)
+                verify(this).visibility = View.GONE
+            }
+    }
+
+    @Test
+    fun `when supplied false, the view is set to visible`() {
+        mock<View>()
+            .apply {
+                goneIf(false)
+                verify(this).visibility = View.VISIBLE
+            }
+    }
+}

--- a/coreui/src/test/java/piuk/blockchain/androidcoreui/utils/extensions/InvisibleIfTest.kt
+++ b/coreui/src/test/java/piuk/blockchain/androidcoreui/utils/extensions/InvisibleIfTest.kt
@@ -1,0 +1,57 @@
+package piuk.blockchain.androidcoreui.utils.extensions
+
+import android.view.View
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.verify
+import org.amshove.kluent.`it returns`
+import org.junit.Test
+
+class InvisibleIfTest {
+
+    @Test
+    fun `when function evaluates to true, the view is set to invisible`() {
+        mock<View>()
+            .apply {
+                invisibleIf { true }
+                verify(this).visibility = View.INVISIBLE
+            }
+    }
+
+    @Test
+    fun `when function evaluates to false, the view is set to visible`() {
+        mock<View>()
+            .apply {
+                invisibleIf { false }
+                verify(this).visibility = View.VISIBLE
+            }
+    }
+
+    @Test
+    fun `when view is null, the function does not evaluate`() {
+        mock<() -> Boolean> {
+            onGeneric { invoke() } `it returns` true
+        }.apply {
+            (null as View?).invisibleIf(this)
+            verify(this, never()).invoke()
+        }
+    }
+
+    @Test
+    fun `when supplied true, the view is set to invisible`() {
+        mock<View>()
+            .apply {
+                invisibleIf(true)
+                verify(this).visibility = View.INVISIBLE
+            }
+    }
+
+    @Test
+    fun `when supplied false, the view is set to visible`() {
+        mock<View>()
+            .apply {
+                invisibleIf(false)
+                verify(this).visibility = View.VISIBLE
+            }
+    }
+}


### PR DESCRIPTION
When no-non-spendable, you don't see anything different:

![no-non-spendable-balance](https://user-images.githubusercontent.com/6041352/43014550-e26dee14-8c22-11e8-81c5-d8703265d09b.png)

With non-spendable:

![btc-non-spendable](https://user-images.githubusercontent.com/6041352/43014601-16fbffae-8c23-11e8-960a-0b23b58965fe.png)

Pressing the "button" toggles BTC/Fiat:

![usd-non-spendable](https://user-images.githubusercontent.com/6041352/43014611-20109ca8-8c23-11e8-8044-62771fc68249.png)
