### PR TITLE
AND-1241 KYC feature flag

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,10 +43,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             multiDexEnabled false
             buildConfigBoolean "USE_CRASHLYTICS", true
+            buildConfigBoolean "HOMEBREW_DISABLED", true // TODO: Enable/remove for release AND-1299
         }
         debug {
             multiDexEnabled true
             buildConfigBoolean "USE_CRASHLYTICS", false
+            buildConfigBoolean "HOMEBREW_DISABLED", false
         }
     }
 
@@ -149,6 +151,7 @@ androidExtensions {
 dependencies {
     implementation project(':coreui')
     implementation project(':buysellui')
+    implementation project(':kyc')
 
     implementation Libraries.multidex
     kapt Libraries.dataBindingKapt

--- a/app/src/main/java/piuk/blockchain/android/injection/ApplicationComponent.java
+++ b/app/src/main/java/piuk/blockchain/android/injection/ApplicationComponent.java
@@ -23,7 +23,8 @@ import piuk.blockchain.androidcoreui.injector.ContextModule;
         ApiModule.class,
         PersistentStoreModule.class,
         ServiceModule.class,
-        ContextModule.class
+        ContextModule.class,
+        KycModule.class,
 })
 public interface ApplicationComponent {
 

--- a/app/src/main/java/piuk/blockchain/android/injection/Injector.java
+++ b/app/src/main/java/piuk/blockchain/android/injection/Injector.java
@@ -23,17 +23,20 @@ public enum Injector {
         ApplicationModule applicationModule = new ApplicationModule();
         ApiModule apiModule = new ApiModule();
         ContextModule contextModule = new ContextModule(applicationContext);
+        KycModule kycModule = new KycModule();
 
-        initAppComponent(applicationModule, apiModule, contextModule);
+        initAppComponent(applicationModule, apiModule, contextModule, kycModule);
     }
 
     protected void initAppComponent(ApplicationModule applicationModule,
                                     ApiModule apiModule,
-                                    ContextModule contextModule) {
+                                    ContextModule contextModule,
+                                    KycModule kycModule) {
         applicationComponent = DaggerApplicationComponent.builder()
                 .contextModule(contextModule)
                 .applicationModule(applicationModule)
                 .apiModule(apiModule)
+                .kycModule(kycModule)
                 .build();
 
         getPresenterComponent();

--- a/app/src/main/java/piuk/blockchain/android/injection/KycModule.kt
+++ b/app/src/main/java/piuk/blockchain/android/injection/KycModule.kt
@@ -1,0 +1,23 @@
+package piuk.blockchain.android.injection
+
+import com.blockchain.kyc.DisabledFeatureFlag
+import com.blockchain.kyc.FeatureFlag
+import dagger.Module
+import dagger.Provides
+import info.blockchain.wallet.api.WalletApi
+import piuk.blockchain.android.BuildConfig
+import piuk.blockchain.android.kyc.KycServerSideFeatureFlag
+import timber.log.Timber
+
+@Module
+class KycModule {
+
+    @Provides
+    fun provideFeatureFlag(walletApi: dagger.Lazy<WalletApi>): FeatureFlag =
+        if (BuildConfig.HOMEBREW_DISABLED) {
+            Timber.w("Homebrew is disabled in build")
+            DisabledFeatureFlag()
+        } else {
+            KycServerSideFeatureFlag(walletApi.get())
+        }
+}

--- a/app/src/main/java/piuk/blockchain/android/kyc/KycServerSideFeatureFlag.kt
+++ b/app/src/main/java/piuk/blockchain/android/kyc/KycServerSideFeatureFlag.kt
@@ -1,0 +1,16 @@
+package piuk.blockchain.android.kyc
+
+import com.blockchain.kyc.FeatureFlag
+import info.blockchain.wallet.api.WalletApi
+import io.reactivex.Single
+
+class KycServerSideFeatureFlag(private val walletApi: WalletApi) : FeatureFlag {
+    override val enabled: Single<Boolean>
+        get() =
+            walletApi
+                .walletOptions
+                .singleOrError()
+                .map {
+                    it.androidFlags["homebrew"] ?: false
+                }
+}

--- a/app/src/test/java/piuk/blockchain/android/kyc/KycServerSideFeatureFlagTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/kyc/KycServerSideFeatureFlagTest.kt
@@ -1,0 +1,54 @@
+package piuk.blockchain.android.kyc
+
+import com.nhaarman.mockito_kotlin.mock
+import info.blockchain.wallet.api.WalletApi
+import info.blockchain.wallet.api.data.WalletOptions
+import io.reactivex.Observable
+import org.amshove.kluent.`it returns`
+import org.junit.Test
+
+class KycServerSideFeatureFlagTest {
+
+    @Test
+    fun `if homebrew is set to true, the feature flag is on`() {
+        mock<WalletApi> {
+            on { walletOptions } `it returns` Observable.just(
+                WalletOptions().apply {
+                    androidFlags["homebrew"] = true
+                }
+            )
+        }.let { KycServerSideFeatureFlag(it) }
+            .apply {
+                enabled.test()
+                    .assertValue(true)
+            }
+    }
+
+    @Test
+    fun `if homebrew is set to false, the feature flag is off`() {
+        mock<WalletApi> {
+            on { walletOptions } `it returns` Observable.just(
+                WalletOptions().apply {
+                    androidFlags["homebrew"] = false
+                }
+            )
+        }.let { KycServerSideFeatureFlag(it) }
+            .apply {
+                enabled.test()
+                    .assertValue(false)
+            }
+    }
+
+    @Test
+    fun `if homebrew is missing, the feature flag is off`() {
+        mock<WalletApi> {
+            on { walletOptions } `it returns` Observable.just(
+                WalletOptions()
+            )
+        }.let { KycServerSideFeatureFlag(it) }
+            .apply {
+                enabled.test()
+                    .assertValue(false)
+            }
+    }
+}

--- a/kyc/build.gradle
+++ b/kyc/build.gradle
@@ -38,6 +38,8 @@ kapt {
     useBuildCache = true
 }
 dependencies {
+    api Libraries.rxKotlin
+
     // Unit Test dependencies
     testImplementation Libraries.junit
     testImplementation Libraries.mockito

--- a/kyc/src/main/java/com/blockchain/kyc/DisabledFeatureFlag.kt
+++ b/kyc/src/main/java/com/blockchain/kyc/DisabledFeatureFlag.kt
@@ -1,0 +1,7 @@
+package com.blockchain.kyc
+
+import io.reactivex.Single
+
+class DisabledFeatureFlag(
+    override val enabled: Single<Boolean> = Single.just(false)
+) : FeatureFlag

--- a/kyc/src/main/java/com/blockchain/kyc/FeatureFlag.kt
+++ b/kyc/src/main/java/com/blockchain/kyc/FeatureFlag.kt
@@ -1,0 +1,8 @@
+package com.blockchain.kyc
+
+import io.reactivex.Single
+
+interface FeatureFlag {
+
+    val enabled: Single<Boolean>
+}

--- a/kyc/src/test/java/com/blockchain/kyc/DisabledFeatureFlagTest.kt
+++ b/kyc/src/test/java/com/blockchain/kyc/DisabledFeatureFlagTest.kt
@@ -1,0 +1,14 @@
+package com.blockchain.kyc
+
+import org.junit.Test
+
+class DisabledFeatureFlagTest {
+
+    @Test
+    fun `enabled returns false`() {
+        DisabledFeatureFlag()
+            .enabled
+            .test()
+            .assertValue(false)
+    }
+}


### PR DESCRIPTION
- I've gone for a shared feature flag name with homebrew.
- We can make it country specific easily with a replacement implementation of `kyc.FeatureFlag`.
- Same story if we move from `options.json` at some point, it's no problem to create a replacement implementation of `kyc.FeatureFlag`.
- For new classes in the new module, I've started going for a base package of `com.blockchain.kyc`, so no `"piuk"` or `"android"`, bit cleaner and reflecting our domain better. What do you think?
