### PR TITLE
fix(ReplaySubject): AND-1306 Fix for issue where ReplaySubject was su…

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -36,7 +36,7 @@ object Versions {
     const val moshi = "1.6.0"
     const val jacksonCore = "2.9.5"
     const val dagger = "2.16"
-    const val rxJava = "2.1.14"
+    const val rxJava = "2.1.17"
     const val rxKotlin = "2.2.0"
     const val rxAndroid = "2.0.2"
     const val rxBinding = "2.1.1"

--- a/core/src/main/java/piuk/blockchain/androidcore/data/walletoptions/WalletOptionsDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/walletoptions/WalletOptionsDataManager.kt
@@ -8,6 +8,7 @@ import io.reactivex.schedulers.Schedulers
 import piuk.blockchain.androidcore.data.auth.AuthService
 import piuk.blockchain.androidcore.data.settings.SettingsDataManager
 import piuk.blockchain.androidcore.injection.PresenterScope
+import piuk.blockchain.androidcore.utils.helperfunctions.unsafeLazy
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Named
@@ -20,8 +21,10 @@ class WalletOptionsDataManager @Inject constructor(
     @Named("explorer-url") private val explorerUrl: String
 ) {
 
-    private val walletOptionsService = authService.getWalletOptions()
-        .cache()
+    private val walletOptionsService by unsafeLazy {
+        authService.getWalletOptions()
+            .cache()
+    }
 
     /**
      * ReplaySubjects will re-emit items it observed.

--- a/core/src/main/java/piuk/blockchain/androidcore/data/walletoptions/WalletOptionsDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/walletoptions/WalletOptionsDataManager.kt
@@ -14,11 +14,14 @@ import javax.inject.Named
 
 @PresenterScope
 class WalletOptionsDataManager @Inject constructor(
-    private val authService: AuthService,
+    authService: AuthService,
     private val walletOptionsState: WalletOptionsState,
     private val settingsDataManager: SettingsDataManager,
     @Named("explorer-url") private val explorerUrl: String
 ) {
+
+    private val walletOptionsService = authService.getWalletOptions()
+        .cache()
 
     /**
      * ReplaySubjects will re-emit items it observed.
@@ -26,7 +29,7 @@ class WalletOptionsDataManager @Inject constructor(
      * the user's country code won't change during an active session.
      */
     private fun initWalletOptionsReplaySubjects() {
-        authService.getWalletOptions()
+        walletOptionsService
             .subscribeOn(Schedulers.io())
             .subscribeWith(walletOptionsState.walletOptionsSource)
     }


### PR DESCRIPTION
…bscribing to an Observable many times potentially on different threads. This resulted in inconsistencies within the ReplaySubject causing crashes. Caching the data (which won't change over the course of a session) fixes the issue.