### PR TITLE
chore(githooks): AND-000: Set file permissions after installing git hooks

### DIFF
--- a/gradle/githooks.gradle
+++ b/gradle/githooks.gradle
@@ -6,6 +6,11 @@ task deleteGitHooksSamples(
     delete '.git/hooks'
 }
 
+task setFilePermissions(type: Exec) {
+    // Mark all files in the .git/hooks directory as executable
+    commandLine 'sh', '-c', 'find .git/hooks -type f -exec chmod 755 {} \\;'
+}
+
 task installGitHooks(
         type: Copy,
         dependsOn: 'deleteGitHooksSamples',
@@ -14,4 +19,7 @@ task installGitHooks(
 ) {
     from 'githooks/'
     into '.git/hooks'
+    doLast {
+      setFilePermissions.execute()
+    }
 }


### PR DESCRIPTION
Marked as `AND-000` as I have no idea what your internal JIRA looks like. 😄 

This simple PR updates your `installGitHooks` command to include setting the file permissions. Therefore, once the command is run, the correct file permissions (executable) will be set on the hooks - preventing manual intervention after the command is run. 

