### PR TITLE
fix(Sending): AND-1329 Fix issue where sending BTC could hang due to …

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/send/SendPresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/send/SendPresenter.kt
@@ -64,7 +64,6 @@ import java.math.BigInteger
 import java.math.RoundingMode
 import java.text.DecimalFormatSymbols
 import java.util.HashMap
-import java.util.Locale
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
@@ -2012,12 +2011,8 @@ class SendPresenter @Inject constructor(
      * If the ratio of fee/amount is over 1%
      */
     private fun isLargeTransaction(): Boolean {
-        val valueString = CryptoValue(CryptoCurrency.BTC, absoluteSuggestedFee)
+        val usdValue = CryptoValue(CryptoCurrency.BTC, absoluteSuggestedFee)
             .toFiat(exchangeRateFactory, "USD")
-            .toStringWithoutSymbol(Locale.getDefault())
-        val usdValue =
-            currencyFormatManager.stripSeparator(valueString, getDefaultDecimalSeparator())
-                .toDouble()
         val txSize = sendDataManager.estimateSize(
             pendingTransaction.unspentOutputBundle.spendableOutputs.size,
             2
@@ -2025,7 +2020,7 @@ class SendPresenter @Inject constructor(
         val relativeFee =
             absoluteSuggestedFee.toDouble() / pendingTransaction.bigIntAmount.toDouble() * 100.0
 
-        return usdValue > SendModel.LARGE_TX_FEE &&
+        return usdValue.value > SendModel.LARGE_TX_FEE.toBigDecimal() &&
             txSize > SendModel.LARGE_TX_SIZE &&
             relativeFee > SendModel.LARGE_TX_PERCENTAGE
     }

--- a/balance/src/main/kotlin/info/blockchain/balance/FiatValue.kt
+++ b/balance/src/main/kotlin/info/blockchain/balance/FiatValue.kt
@@ -43,6 +43,7 @@ data class FiatValue(
     fun toStringWithoutSymbol(locale: Locale): String =
         FiatFormat[Key(locale, currencyCode, includeSymbol = false)]
             .format(value)
+            .trim()
 
     operator fun plus(other: FiatValue): FiatValue {
         if (currencyCode != other.currencyCode)

--- a/balance/src/test/kotlin/info/blockchain/balance/FiatValueTests.kt
+++ b/balance/src/test/kotlin/info/blockchain/balance/FiatValueTests.kt
@@ -116,6 +116,12 @@ class FiatValueTests {
     }
 
     @Test
+    fun `can format USD without symbol in ES`() {
+        FiatValue("USD", 0.07.toBigDecimal())
+            .toStringWithoutSymbol(Locale("es_ES")) `should equal` "0.07"
+    }
+
+    @Test
     fun `isZero`() {
         FiatValue("GBP", 0.toBigDecimal()).isZero `should be` true
     }


### PR DESCRIPTION
…extraneous whitespace left after removing a currency symbol in some regions. (#1099)