### PR TITLE
chore(Gradle): AND-1341 Remove allopen and unnecessary Kapts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'io.fabric'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-allopen'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.novoda.build-properties'
 apply from: '../quality/jacocoApp.gradle'
@@ -138,10 +137,6 @@ android {
 
 kapt {
     useBuildCache = true
-}
-
-allOpen {
-    annotation("piuk.blockchain.androidcore.utils.annotations.Mockable")
 }
 
 androidExtensions {

--- a/app/src/main/java/piuk/blockchain/android/data/bitcoincash/BchDataManager.kt
+++ b/app/src/main/java/piuk/blockchain/android/data/bitcoincash/BchDataManager.kt
@@ -21,13 +21,11 @@ import piuk.blockchain.androidcore.data.payload.PayloadDataManager
 import piuk.blockchain.androidcore.data.rxjava.RxBus
 import piuk.blockchain.androidcore.data.rxjava.RxPinning
 import piuk.blockchain.androidcore.injection.PresenterScope
-import piuk.blockchain.androidcore.utils.annotations.Mockable
 import piuk.blockchain.androidcore.utils.annotations.WebRequest
 import piuk.blockchain.androidcore.utils.extensions.applySchedulers
 import java.math.BigInteger
 import javax.inject.Inject
 
-@Mockable
 @PresenterScope
 class BchDataManager @Inject constructor(
     private val payloadDataManager: PayloadDataManager,

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
         classpath Libraries.coveralls
         classpath Libraries.googleServicesPlugin
         classpath Libraries.kotlinGradlePlugin
-        classpath Libraries.kotlinAllOpen
         classpath Libraries.jacoco
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -100,7 +100,6 @@ object Libraries {
     const val androidGradlePlugin = "com.android.tools.build:gradle:${Versions.androidPlugin}"
     const val kotlinGradlePlugin = "org.jetbrains.kotlin:kotlin-gradle-plugin:${Versions.kotlin}"
     const val kotlin = "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${Versions.kotlin}"
-    const val kotlinAllOpen = "org.jetbrains.kotlin:kotlin-allopen:${Versions.kotlin}"
     const val coveralls = "org.kt3k.gradle.plugin:coveralls-gradle-plugin:${Versions.coveralls}"
     const val googleServicesPlugin =
         "com.google.gms:google-services:${Versions.googleServicesPlugin}"

--- a/buysell/build.gradle
+++ b/buysell/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-allopen'
-apply plugin: 'kotlin-kapt'
 apply from: '../quality/jacocoLibrary.gradle'
 apply from: '../quality/ktlint.gradle'
 
@@ -16,15 +14,6 @@ android {
         versionName Versions.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
-    }
-
-    buildTypes {
-        release {
-
-        }
-        debug {
-
-        }
     }
 
     compileOptions {
@@ -43,22 +32,12 @@ android {
     }
 }
 
-kapt {
-    useBuildCache = true
-}
-
-allOpen {
-    annotation("piuk.blockchain.androidcore.utils.annotations.Mockable")
-}
-
 androidExtensions {
     experimental = true
 }
 
 dependencies {
     api project(':core')
-    // Dagger
-    kapt Libraries.daggerKapt
     api Libraries.koin
 
     // Unit Test dependencies

--- a/buysellui/build.gradle
+++ b/buysellui/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-allopen'
-apply plugin: 'kotlin-kapt'
 apply from: '../quality/jacocoLibrary.gradle'
 apply from: '../quality/ktlint.gradle'
 
@@ -16,15 +14,6 @@ android {
         versionName Versions.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
-    }
-
-    buildTypes {
-        release {
-
-        }
-        debug {
-
-        }
     }
 
     compileOptions {
@@ -43,14 +32,6 @@ android {
     }
 }
 
-kapt {
-    useBuildCache = true
-}
-
-allOpen {
-    annotation("piuk.blockchain.androidcore.utils.annotations.Mockable")
-}
-
 androidExtensions {
     experimental = true
 }
@@ -58,8 +39,6 @@ androidExtensions {
 dependencies {
     implementation project(':coreui')
     api project(':buysell')
-    // Dagger
-    kapt Libraries.daggerKapt
 
     // Unit Test dependencies
     testImplementation Libraries.junit

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-allopen'
-apply plugin: 'kotlin-kapt'
 apply from: '../quality/jacocoLibrary.gradle'
 apply from: '../quality/ktlint.gradle'
 
@@ -14,15 +12,6 @@ android {
         versionCode Versions.versionCode
         versionName Versions.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-
-        }
-        debug {
-
-        }
     }
 
     compileOptions {
@@ -41,14 +30,6 @@ android {
     }
 }
 
-kapt {
-    useBuildCache = true
-}
-
-allOpen {
-    annotation("piuk.blockchain.androidcore.utils.annotations.Mockable")
-}
-
 dependencies {
     api project(':wallet')
     api project(':balance')
@@ -62,7 +43,6 @@ dependencies {
     api Libraries.okHttpInterceptor
     // Dagger
     api Libraries.dagger
-    kapt Libraries.daggerKapt
     api Libraries.koin
     // RxJava
     api Libraries.rxJava

--- a/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyFormatManager.kt
@@ -12,7 +12,6 @@ import piuk.blockchain.androidcore.data.exchangerate.ExchangeRateDataManager
 import piuk.blockchain.androidcore.data.exchangerate.toFiat
 import piuk.blockchain.androidcore.injection.PresenterScope
 import piuk.blockchain.androidcore.utils.PrefsUtil
-import piuk.blockchain.androidcore.utils.annotations.Mockable
 import piuk.blockchain.androidcore.utils.helperfunctions.InvalidatableLazy
 import java.math.BigDecimal
 import java.math.BigInteger
@@ -23,7 +22,6 @@ import java.util.Currency
 import java.util.Locale
 import javax.inject.Inject
 
-@Mockable
 @PresenterScope
 class CurrencyFormatManager @Inject constructor(
     private val currencyState: CurrencyState,

--- a/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyState.java
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/currency/CurrencyState.java
@@ -5,13 +5,11 @@ import java.util.Locale;
 
 import info.blockchain.balance.CryptoCurrency;
 import piuk.blockchain.androidcore.utils.PrefsUtil;
-import piuk.blockchain.androidcore.utils.annotations.Mockable;
 
 /**
  * Singleton class to store user's preferred crypto currency state.
  * (ie is Wallet currently showing FIAT, ETH, BTC ot BCH)
  */
-@Mockable
 public class CurrencyState {
 
     private static CurrencyState INSTANCE;

--- a/core/src/main/java/piuk/blockchain/androidcore/data/metadata/MetadataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/metadata/MetadataManager.kt
@@ -11,7 +11,6 @@ import piuk.blockchain.androidcore.data.rxjava.RxBus
 import piuk.blockchain.androidcore.data.rxjava.RxPinning
 import piuk.blockchain.androidcore.injection.PresenterScope
 import piuk.blockchain.androidcore.utils.MetadataUtils
-import piuk.blockchain.androidcore.utils.annotations.Mockable
 import piuk.blockchain.androidcore.utils.extensions.applySchedulers
 import javax.inject.Inject
 
@@ -29,7 +28,6 @@ import javax.inject.Inject
  * keys with just a user's credentials and not derive them again.
  *
  */
-@Mockable
 @PresenterScope
 class MetadataManager @Inject constructor(
     private val payloadDataManager: PayloadDataManager,

--- a/core/src/main/java/piuk/blockchain/androidcore/data/payload/PayloadDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/payload/PayloadDataManager.kt
@@ -22,7 +22,6 @@ import piuk.blockchain.androidcore.data.api.EnvironmentConfig
 import piuk.blockchain.androidcore.data.rxjava.RxBus
 import piuk.blockchain.androidcore.data.rxjava.RxPinning
 import piuk.blockchain.androidcore.injection.PresenterScope
-import piuk.blockchain.androidcore.utils.annotations.Mockable
 import piuk.blockchain.androidcore.utils.extensions.applySchedulers
 import piuk.blockchain.androidcore.utils.rxjava.IgnorableDefaultObserver
 import java.io.UnsupportedEncodingException
@@ -31,7 +30,6 @@ import java.util.ArrayList
 import java.util.LinkedHashMap
 import javax.inject.Inject
 
-@Mockable
 @PresenterScope
 class PayloadDataManager @Inject constructor(
     private val payloadService: PayloadService,

--- a/core/src/main/java/piuk/blockchain/androidcore/utils/annotations/Mockable.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/utils/annotations/Mockable.kt
@@ -1,9 +1,0 @@
-package piuk.blockchain.androidcore.utils.annotations
-
-/**
- * This annotation is used both to "open" a class that is otherwise final by default (as is the case
- * with all Kotlin classes) and signify that the class is able to be mocked for testing classes
- * which depend on the annotated class. Note that this annotation also implicitly means that
- * the class was not designed to be extended.
- */
-annotation class Mockable

--- a/coreui/build.gradle
+++ b/coreui/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-allopen'
 apply from: '../quality/jacocoLibrary.gradle'
 apply from: '../quality/ktlint.gradle'
 
@@ -40,10 +39,6 @@ android {
             reports.junitXml.destination = file('../build/test-results/')
         }
     }
-}
-
-allOpen {
-    annotation("piuk.blockchain.androidcore.utils.annotations.Mockable")
 }
 
 androidExtensions {

--- a/kyc/build.gradle
+++ b/kyc/build.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
-apply plugin: 'kotlin-allopen'
-apply plugin: 'kotlin-kapt'
 apply plugin: 'com.novoda.build-properties'
 apply from: '../quality/jacocoLibrary.gradle'
 apply from: '../quality/ktlint.gradle'
@@ -46,10 +44,6 @@ android {
             reports.junitXml.destination = file('../build/test-results/')
         }
     }
-}
-
-kapt {
-    useBuildCache = true
 }
 
 androidExtensions {


### PR DESCRIPTION
- `:app` has the only `kapt` usage after this.
- `Mockable` and `allopen` was made defunct with `mock-maker-inline` a while back.