### PR TITLE
feat(HomeBrew): AND-1335 auth refactor part3

### DIFF
--- a/kyc/src/main/java/com/blockchain/injection/kycModule.kt
+++ b/kyc/src/main/java/com/blockchain/injection/kycModule.kt
@@ -1,5 +1,6 @@
 package com.blockchain.injection
 
+import com.blockchain.kyc.datamanagers.nabu.NabuAuthenticator
 import com.blockchain.kyc.datamanagers.nabu.NabuDataManager
 import com.blockchain.kyc.datamanagers.onfido.OnfidoDataManager
 import com.blockchain.kyc.models.nabu.KycStateAdapter
@@ -14,6 +15,7 @@ import com.blockchain.kycui.mobile.validation.KycMobileValidationPresenter
 import com.blockchain.kycui.onfidosplash.OnfidoSplashPresenter
 import com.blockchain.kycui.profile.KycProfilePresenter
 import com.blockchain.kycui.status.KycStatusPresenter
+import com.blockchain.nabu.Authenticator
 import com.blockchain.nabu.stores.NabuSessionTokenStore
 import com.blockchain.network.modules.MoshiBuilderInterceptor
 import com.squareup.moshi.Moshi
@@ -43,6 +45,10 @@ val kycModule = applicationContext {
                 get(),
                 get()
             )
+        }
+
+        factory {
+            NabuAuthenticator(get(), get()) as Authenticator
         }
 
         factory { KycCountrySelectionPresenter(get()) }

--- a/kyc/src/main/java/com/blockchain/kyc/datamanagers/nabu/NabuAuthenticator.kt
+++ b/kyc/src/main/java/com/blockchain/kyc/datamanagers/nabu/NabuAuthenticator.kt
@@ -1,0 +1,18 @@
+package com.blockchain.kyc.datamanagers.nabu
+
+import com.blockchain.kycui.extensions.fetchNabuToken
+import com.blockchain.nabu.Authenticator
+import com.blockchain.nabu.models.NabuSessionTokenResponse
+import io.reactivex.Single
+import piuk.blockchain.androidcore.data.metadata.MetadataManager
+
+internal class NabuAuthenticator(
+    private val metadataManager: MetadataManager,
+    private val nabuDataManager: NabuDataManager
+) : Authenticator {
+    override fun <T> authenticate(singleFunction: (NabuSessionTokenResponse) -> Single<T>): Single<T> =
+        metadataManager.fetchNabuToken()
+            .flatMap { tokenResponse ->
+                nabuDataManager.authenticate(tokenResponse, singleFunction)
+            }
+}

--- a/kyc/src/main/java/com/blockchain/kyc/datamanagers/nabu/NabuDataManager.kt
+++ b/kyc/src/main/java/com/blockchain/kyc/datamanagers/nabu/NabuDataManager.kt
@@ -150,7 +150,7 @@ class NabuDataManager(
         (it as? NabuApiException?)?.getErrorCode() == NabuErrorCodes.TokenExpired
 
     // TODO: Refactor this logic into a reusable, thoroughly tested class - see AND-1335
-    private fun <T> authenticate(
+    internal fun <T> authenticate(
         offlineToken: NabuOfflineTokenResponse,
         singleFunction: (NabuSessionTokenResponse) -> Single<T>
     ): Single<T> =

--- a/kyc/src/test/java/com/blockchain/kyc/datamanagers/nabu/NabuDataManagerAsAuthenticatorTest.kt
+++ b/kyc/src/test/java/com/blockchain/kyc/datamanagers/nabu/NabuDataManagerAsAuthenticatorTest.kt
@@ -1,0 +1,48 @@
+package com.blockchain.kyc.datamanagers.nabu
+
+import com.blockchain.nabu.Authenticator
+import com.blockchain.nabu.metadata.NabuCredentialsMetadata
+import com.blockchain.nabu.models.NabuOfflineTokenResponse
+import com.blockchain.nabu.models.NabuSessionTokenResponse
+import com.blockchain.serialization.toMoshiJson
+import com.google.common.base.Optional
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
+import io.reactivex.Observable
+import io.reactivex.Single
+import org.amshove.kluent.`it returns`
+import org.junit.Test
+import piuk.blockchain.androidcore.data.metadata.MetadataManager
+
+class NabuDataManagerAsAuthenticatorTest {
+
+    @Test
+    fun `the token is fetched and passed to the manager`() {
+
+        val metadataManager = givenMetaDataContainingToken("User", "ABC")
+
+        val nabuDataManager = mock<NabuDataManager>()
+        val sut = NabuAuthenticator(metadataManager, nabuDataManager) as Authenticator
+
+        val theFunction = mock<(NabuSessionTokenResponse) -> Single<Int>>()
+        sut.authenticate(theFunction)
+            .test()
+
+        verify(nabuDataManager).authenticate(
+            eq(NabuOfflineTokenResponse("User", "ABC")),
+            any<(NabuSessionTokenResponse) -> Single<Int>>()
+        )
+        verifyNoMoreInteractions(nabuDataManager)
+    }
+
+    private fun givenMetaDataContainingToken(userId: String, token: String): MetadataManager {
+        val offlineToken = NabuCredentialsMetadata(userId, token)
+        return mock {
+            on { fetchMetadata(NabuCredentialsMetadata.USER_CREDENTIALS_METADATA_NODE) } `it returns`
+                Observable.just<Optional<String>>(Optional.of(offlineToken.toMoshiJson()))
+        }
+    }
+}

--- a/nabu/src/main/kotlin/com/blockchain/nabu/Authenticator.kt
+++ b/nabu/src/main/kotlin/com/blockchain/nabu/Authenticator.kt
@@ -1,0 +1,11 @@
+package com.blockchain.nabu
+
+import com.blockchain.nabu.models.NabuSessionTokenResponse
+import io.reactivex.Single
+
+interface Authenticator {
+
+    fun <T> authenticate(
+        singleFunction: (NabuSessionTokenResponse) -> Single<T>
+    ): Single<T>
+}


### PR DESCRIPTION
- Add general Nabu authenticator interface - this is not fully generic, but I don't see any value in that just yet and the `Authenticator` interface is in the nabu package.
- After struggling to detach Auth from the data manager (mainly due to tests being hard to refactor), I ended up wrapping it.