### PR TITLE
chore(Build): AND-1396 Fix incremental build speed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,9 @@ allprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
-    subprojects.forEach { delete it.buildDir }
+    doLast {
+        subprojects.forEach { delete it.buildDir }
+    }
 }
 
 apply from: 'quality/jacocoRootReport.gradle'


### PR DESCRIPTION
Morph Dev app
===

Zero change (2nd run) `./gradlew :morph:morphDevApp:assembleDebug --scan`

Before: https://gradle.com/s/y55xk6l7kyvq4
```
BUILD SUCCESSFUL in 28s
109 actionable tasks: 33 executed, 72 from cache, 4 up-to-date
```

After: https://gradle.com/s/3qhvm5cwfzqvg
```
BUILD SUCCESSFUL in 3s
109 actionable tasks: 109 up-to-date
```

Didn't even have to go to the local cache for any tasks.

Main App
===
Zero change (2nd run): `./gradlew :app:assembleEnvProdDebug --scan`

Before: https://gradle.com/s/7t6jrcaxc4koy
```
BUILD SUCCESSFUL in 1m 57s
208 actionable tasks: 66 executed, 134 from cache, 8 up-to-date
```

After: https://gradle.com/s/bf2xemzm2cbtc
```
BUILD SUCCESSFUL in 27s
208 actionable tasks: 10 executed, 198 up-to-date
```

App with no cache
===

Zero change (2nd run): `./gradlew :app:assembleEnvProdDebug --no-build-cache --scan`
Simulates an empty cache.

Before with no cache: https://gradle.com/s/hi4gyifh5tpqa

```
BUILD SUCCESSFUL in 1m 51s
208 actionable tasks: 200 executed, 8 up-to-date
```

After with no cache: https://gradle.com/s/23cuo4d6l5xle
```
BUILD SUCCESSFUL in 27s
208 actionable tasks: 10 executed, 198 up-to-date
```

No difference as expected, as no results needed to come from the cache.

Note how many tasks were up to date. As every build dir got wiped during configuration, most tasks were rerun. Also note how much better being up-to-date is over cached.

Android Studio experience improvements
===

In addition, whenever you refreshed gradle from Android Studio or ran or did anything that would hit gradle in anyway, this also wiped the dirs as even `./gradlew` alone would wipe the dirs. This is probably responsible for some of the worst kotlinx, `R` class and other IDE issues as generated classes were deleted frequently.
