### PR TITLE
feat(HomeBrew): AND-1374 Use existing account picker in HomeBrew

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/ui/account/ItemAccount.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/account/ItemAccount.kt
@@ -1,5 +1,7 @@
 package piuk.blockchain.android.ui.account
 
+import com.blockchain.serialization.JsonSerializableAccount
+
 @Suppress("LeakingThis")
 class ItemAccount {
 
@@ -12,9 +14,8 @@ class ItemAccount {
     var tag: String? = null
     var absoluteBalance: Long? = null
 
-    // TODO Get rid of this Any
     // Ultimately this is used to sign txs
-    var accountObject: Any? = null
+    var accountObject: JsonSerializableAccount? = null
 
     // Address/Xpub to fetch balance/tx list
     var address: String? = null
@@ -40,7 +41,7 @@ class ItemAccount {
         displayBalance: String?,
         tag: String?,
         absoluteBalance: Long?,
-        accountObject: Any? = null,
+        accountObject: JsonSerializableAccount? = null,
         address: String?,
         type: TYPE = TYPE.SINGLE_ACCOUNT
     ) {

--- a/app/src/main/java/piuk/blockchain/android/ui/shapeshift/newexchange/NewExchangeActivity.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/shapeshift/newexchange/NewExchangeActivity.kt
@@ -14,7 +14,6 @@ import android.support.v4.content.LocalBroadcastManager
 import android.support.v7.app.AlertDialog
 import android.view.View
 import android.widget.EditText
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.jakewharton.rxbinding2.widget.RxTextView
 import info.blockchain.wallet.coin.GenericMetadataAccount
 import info.blockchain.wallet.ethereum.EthereumAccount
@@ -166,20 +165,14 @@ class NewExchangeActivity : BaseMvpActivity<NewExchangeView, NewExchangePresente
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         if (resultCode == Activity.RESULT_OK && data != null) {
-
-            val clazz =
-                Class.forName(data.getStringExtra(AccountChooserActivity.EXTRA_SELECTED_OBJECT_TYPE))
-            val any = ObjectMapper().readValue(
-                data.getStringExtra(AccountChooserActivity.EXTRA_SELECTED_ITEM),
-                clazz
-            )
-            when (any) {
+            val account = AccountChooserActivity.getSelectedRawAccount(data)
+            when (account) {
                 is Account -> {
                     when (requestCode) {
                         REQUEST_CODE_CHOOSE_SENDING_ACCOUNT_FROM_SEND ->
-                            presenter.onFromAccountChanged(any)
+                            presenter.onFromAccountChanged(account)
                         REQUEST_CODE_CHOOSE_RECEIVING_ACCOUNT_FROM_SEND ->
-                            presenter.onToAccountChanged(any)
+                            presenter.onToAccountChanged(account)
                         else -> throw IllegalArgumentException("Unknown request code $requestCode")
                     }
                 }
@@ -195,13 +188,13 @@ class NewExchangeActivity : BaseMvpActivity<NewExchangeView, NewExchangePresente
                 is GenericMetadataAccount -> {
                     when (requestCode) {
                         REQUEST_CODE_CHOOSE_SENDING_ACCOUNT_FROM_SEND ->
-                            presenter.onFromBchAccountChanged(any)
+                            presenter.onFromBchAccountChanged(account)
                         REQUEST_CODE_CHOOSE_RECEIVING_ACCOUNT_FROM_SEND ->
-                            presenter.onToBchAccountChanged(any)
+                            presenter.onToBchAccountChanged(account)
                         else -> throw IllegalArgumentException("Unknown request code $requestCode")
                     }
                 }
-                else -> throw IllegalArgumentException("Unsupported class type $clazz")
+                else -> throw IllegalArgumentException("Unsupported class type")
             }
 
             clearError()

--- a/app/src/test/java/piuk/blockchain/android/ui/chooser/WalletAccountHelperAccountListingAdapterTest.kt
+++ b/app/src/test/java/piuk/blockchain/android/ui/chooser/WalletAccountHelperAccountListingAdapterTest.kt
@@ -1,5 +1,6 @@
 package piuk.blockchain.android.ui.chooser
 
+import com.blockchain.serialization.JsonSerializableAccount
 import com.blockchain.ui.chooser.AccountChooserItem
 import com.blockchain.ui.chooser.AccountListing
 import com.nhaarman.mockito_kotlin.mock
@@ -17,7 +18,7 @@ class WalletAccountHelperAccountListingAdapterTest {
 
     @Test
     fun `BTC accounts`() {
-        val account = mock<Any>()
+        val account = mock<JsonSerializableAccount>()
         val walletAccountHelper = mock<WalletAccountHelper> {
             on { getHdAccounts() } `it returns` listOf(
                 ItemAccount().apply {
@@ -37,7 +38,7 @@ class WalletAccountHelperAccountListingAdapterTest {
 
     @Test
     fun `BCH accounts`() {
-        val account = mock<Any>()
+        val account = mock<JsonSerializableAccount>()
         val walletAccountHelper = mock<WalletAccountHelper> {
             on { getHdBchAccounts() } `it returns` listOf(
                 ItemAccount().apply {
@@ -57,7 +58,7 @@ class WalletAccountHelperAccountListingAdapterTest {
 
     @Test
     fun `ETH accounts`() {
-        val account = mock<Any>()
+        val account = mock<JsonSerializableAccount>()
         val walletAccountHelper = mock<WalletAccountHelper> {
             on { getEthAccount() } `it returns` listOf(
                 ItemAccount().apply {
@@ -157,7 +158,7 @@ class WalletAccountHelperAccountListingAdapterTest {
 
     @Test
     fun `BTC imported (legacy) addresses - null address when not a legacy`() {
-        val account = mock<Any>()
+        val account = mock<JsonSerializableAccount>()
         val walletAccountHelper = mock<WalletAccountHelper> {
             on { getLegacyAddresses() } `it returns` listOf(
                 ItemAccount().apply {

--- a/common/network/src/main/kotlin/com/blockchain/serialization/JsonSerializable.kt
+++ b/common/network/src/main/kotlin/com/blockchain/serialization/JsonSerializable.kt
@@ -21,8 +21,10 @@ fun <T : JsonSerializable> KClass<T>.fromMoshiJson(json: String): T {
 /**
  * Serialize any [JsonSerializable] to a [String] using Moshi.
  */
-inline fun <reified T : JsonSerializable> T.toMoshiJson(): String {
+inline fun <reified T : JsonSerializable> T.toMoshiJson() = toMoshiJson(T::class.java)
+
+inline fun <reified T : JsonSerializable> T.toMoshiJson(clazz: Class<T>): String {
     val moshi = Moshi.Builder().build()
-    val jsonAdapter = moshi.adapter(T::class.java)
+    val jsonAdapter = moshi.adapter(clazz)
     return jsonAdapter.toJson(this)
 }

--- a/coreui/src/main/java/com/blockchain/koin/coreUiModule.kt
+++ b/coreui/src/main/java/com/blockchain/koin/coreUiModule.kt
@@ -5,7 +5,10 @@ import com.blockchain.ui.chooser.AccountChooserPresenter
 
 val coreUiModule = applicationContext {
 
-    factory {
-        AccountChooserPresenter(get(), get(), get())
+    context("Payload") {
+
+        factory {
+            AccountChooserPresenter(get(), get(), get())
+        }
     }
 }

--- a/coreui/src/main/java/com/blockchain/ui/chooser/AccountChooserAdapter.kt
+++ b/coreui/src/main/java/com/blockchain/ui/chooser/AccountChooserAdapter.kt
@@ -5,15 +5,16 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import com.blockchain.serialization.JsonSerializableAccount
 import piuk.blockchain.androidcoreui.R
 import piuk.blockchain.androidcoreui.utils.extensions.goneIf
 
 class AccountChooserAdapter(
     private val items: List<AccountChooserItem>,
-    private val clickEvent: (Any) -> Unit
+    private val clickEvent: (JsonSerializableAccount) -> Unit
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
-    private fun clickListener(account: Any?): View.OnClickListener = View.OnClickListener {
+    private fun <T : JsonSerializableAccount> clickListener(account: T?): View.OnClickListener = View.OnClickListener {
         if (account != null) {
             clickEvent(account)
         }

--- a/coreui/src/main/java/com/blockchain/ui/chooser/AccountChooserItem.kt
+++ b/coreui/src/main/java/com/blockchain/ui/chooser/AccountChooserItem.kt
@@ -1,5 +1,7 @@
 package com.blockchain.ui.chooser
 
+import com.blockchain.serialization.JsonSerializableAccount
+
 sealed class AccountChooserItem(val label: String) {
     class Header(
         label: String
@@ -7,13 +9,13 @@ sealed class AccountChooserItem(val label: String) {
 
     class Contact(
         label: String,
-        val accountObject: Any?
+        val accountObject: JsonSerializableAccount?
     ) : AccountChooserItem(label)
 
     class AccountSummary(
         label: String,
         val displayBalance: String,
-        val accountObject: Any?
+        val accountObject: JsonSerializableAccount?
     ) : AccountChooserItem(label)
 
     class LegacyAddress(
@@ -21,6 +23,6 @@ sealed class AccountChooserItem(val label: String) {
         val address: String?,
         val displayBalance: String,
         val isWatchOnly: Boolean,
-        val accountObject: Any?
+        val accountObject: JsonSerializableAccount?
     ) : AccountChooserItem(label)
 }

--- a/morph/ui/src/main/java/com/blockchain/morph/ui/homebrew/exchange/ExchangeActivity.kt
+++ b/morph/ui/src/main/java/com/blockchain/morph/ui/homebrew/exchange/ExchangeActivity.kt
@@ -1,5 +1,6 @@
 package com.blockchain.morph.ui.homebrew.exchange
 
+import android.app.Activity
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProviders
 import android.content.Context
@@ -13,6 +14,8 @@ import com.blockchain.morph.exchange.mvi.ExchangeIntent
 import com.blockchain.morph.exchange.mvi.FieldUpdateIntent
 import com.blockchain.morph.exchange.mvi.initial
 import com.blockchain.morph.ui.R
+import com.blockchain.ui.chooser.AccountChooserActivity
+import com.blockchain.ui.chooser.AccountMode
 import info.blockchain.balance.CryptoCurrency
 import info.blockchain.balance.CryptoValue
 import info.blockchain.balance.FiatValue
@@ -91,6 +94,23 @@ class ExchangeActivity : AppCompatActivity() {
         keyboard = findViewById(R.id.numericKeyboard)
         selectSendAccountButton = findViewById(R.id.select_from_account_button)
         selectReceiveAccountButton = findViewById(R.id.select_to_account_button)
+
+        selectSendAccountButton.setOnClickListener {
+            AccountChooserActivity.startForResult(
+                this@ExchangeActivity,
+                AccountMode.Exchange,
+                REQUEST_CODE_CHOOSE_SENDING_ACCOUNT,
+                R.string.from
+            )
+        }
+        selectReceiveAccountButton.setOnClickListener {
+            AccountChooserActivity.startForResult(
+                this@ExchangeActivity,
+                AccountMode.Exchange,
+                REQUEST_CODE_CHOOSE_RECEIVING_ACCOUNT,
+                R.string.to
+            )
+        }
     }
 
     override fun onResume() {
@@ -163,4 +183,21 @@ class ExchangeActivity : AppCompatActivity() {
         compositeDisposable.clear()
         super.onPause()
     }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (resultCode == Activity.RESULT_OK && data != null) {
+            val account = AccountChooserActivity.getSelectedAccount(data)
+            when (requestCode) {
+                REQUEST_CODE_CHOOSE_SENDING_ACCOUNT ->
+                    Timber.d("new ${account.cryptoCurrency} from account $account")
+                REQUEST_CODE_CHOOSE_RECEIVING_ACCOUNT ->
+                    Timber.d("new ${account.cryptoCurrency} to account $account")
+                else -> throw IllegalArgumentException("Unknown request code $requestCode")
+            }
+        }
+    }
 }
+
+private const val REQUEST_CODE_CHOOSE_RECEIVING_ACCOUNT = 800
+private const val REQUEST_CODE_CHOOSE_SENDING_ACCOUNT = 801

--- a/wallet/src/main/java/com/blockchain/serialization/JsonSerializableAccount.kt
+++ b/wallet/src/main/java/com/blockchain/serialization/JsonSerializableAccount.kt
@@ -1,0 +1,3 @@
+package com.blockchain.serialization
+
+interface JsonSerializableAccount : JsonSerializable

--- a/wallet/src/main/java/info/blockchain/wallet/coin/GenericMetadataAccount.java
+++ b/wallet/src/main/java/info/blockchain/wallet/coin/GenericMetadataAccount.java
@@ -1,5 +1,6 @@
 package info.blockchain.wallet.coin;
 
+import com.blockchain.serialization.JsonSerializableAccount;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -22,7 +23,7 @@ import java.io.IOException;
     setterVisibility = Visibility.NONE,
     creatorVisibility = Visibility.NONE,
     isGetterVisibility = Visibility.NONE)
-public class GenericMetadataAccount {
+public class GenericMetadataAccount implements JsonSerializableAccount {
 
     @JsonProperty("label")
     private String label;

--- a/wallet/src/main/java/info/blockchain/wallet/contacts/data/Contact.java
+++ b/wallet/src/main/java/info/blockchain/wallet/contacts/data/Contact.java
@@ -1,5 +1,6 @@
 package info.blockchain.wallet.contacts.data;
 
+import com.blockchain.serialization.JsonSerializableAccount;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -24,7 +25,7 @@ import javax.annotation.Nullable;
     setterVisibility = Visibility.NONE,
     creatorVisibility = Visibility.NONE,
     isGetterVisibility = Visibility.NONE)
-public class Contact {
+public class Contact implements JsonSerializableAccount {
 
     @JsonProperty("id")
     private String id;

--- a/wallet/src/main/java/info/blockchain/wallet/ethereum/EthereumAccount.java
+++ b/wallet/src/main/java/info/blockchain/wallet/ethereum/EthereumAccount.java
@@ -1,5 +1,6 @@
 package info.blockchain.wallet.ethereum;
 
+import com.blockchain.serialization.JsonSerializableAccount;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -25,7 +26,7 @@ import java.util.Arrays;
     setterVisibility = Visibility.NONE,
     creatorVisibility = Visibility.NONE,
     isGetterVisibility = Visibility.NONE)
-public class EthereumAccount {
+public class EthereumAccount implements JsonSerializableAccount {
 
     private static final String DERIVATION_PATH = "m/44'/60'/0'/0";
     private static final int DERIVATION_PATH_PURPOSE = 44;

--- a/wallet/src/main/java/info/blockchain/wallet/payload/data/Account.java
+++ b/wallet/src/main/java/info/blockchain/wallet/payload/data/Account.java
@@ -1,5 +1,6 @@
 package info.blockchain.wallet.payload.data;
 
+import com.blockchain.serialization.JsonSerializableAccount;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -18,7 +19,7 @@ import java.util.List;
     setterVisibility = Visibility.NONE,
     creatorVisibility = Visibility.NONE,
     isGetterVisibility = Visibility.NONE)
-public class Account {
+public class Account implements JsonSerializableAccount {
 
     @JsonProperty("label")
     private String label;

--- a/wallet/src/main/java/info/blockchain/wallet/payload/data/LegacyAddress.java
+++ b/wallet/src/main/java/info/blockchain/wallet/payload/data/LegacyAddress.java
@@ -1,5 +1,6 @@
 package info.blockchain.wallet.payload.data;
 
+import com.blockchain.serialization.JsonSerializableAccount;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -19,7 +20,7 @@ import java.io.IOException;
         setterVisibility = Visibility.NONE,
         creatorVisibility = Visibility.NONE,
         isGetterVisibility = Visibility.NONE)
-public class LegacyAddress {
+public class LegacyAddress implements JsonSerializableAccount {
 
     public static final int NORMAL_ADDRESS = 0;
     public static final int ARCHIVED_ADDRESS = 2;


### PR DESCRIPTION
- Just logs the result of the selection
- Identical to shapeshift's one, I'd already made this general (available in `:coreui`) restyle can come later, and we should discuss if we even want different user experience from different places in the app. This one is used for sending and receiving as well for example.

![image](https://user-images.githubusercontent.com/6041352/44996895-db9d6480-af80-11e8-8e56-cf3f66b90d9b.png)

![image](https://user-images.githubusercontent.com/6041352/44996833-8eb98e00-af80-11e8-979e-90b36e4de15d.png)
