### PR TITLE
feat(WebSocket): AND-1325 Enforce the marker interface JsonSerializable on Json Web Socket

### DIFF
--- a/common/network/src/main/kotlin/com/blockchain/network/websocket/MoshiJsonWebSocketDecorator.kt
+++ b/common/network/src/main/kotlin/com/blockchain/network/websocket/MoshiJsonWebSocketDecorator.kt
@@ -1,12 +1,15 @@
 package com.blockchain.network.websocket
 
+import com.blockchain.serialization.JsonSerializable
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import io.reactivex.Observable
 
-inline fun <reified OUTGOING : Any, reified INCOMING : Any> WebSocket<String, String>.toJsonSocket(
-    moshi: Moshi
-): WebSocket<OUTGOING, INCOMING> {
+inline fun <
+    reified OUTGOING : JsonSerializable,
+    reified INCOMING : JsonSerializable
+    >
+    WebSocket<String, String>.toJsonSocket(moshi: Moshi): WebSocket<OUTGOING, INCOMING> {
     return MoshiJsonWebSocketDecorator(this, moshi.adapter(OUTGOING::class.java), moshi.adapter(INCOMING::class.java))
 }
 

--- a/common/network/src/test/kotlin/com/blockchain/network/websocket/MoshiJsonWebSocketDecoratorTest.kt
+++ b/common/network/src/test/kotlin/com/blockchain/network/websocket/MoshiJsonWebSocketDecoratorTest.kt
@@ -1,5 +1,6 @@
 package com.blockchain.network.websocket
 
+import com.blockchain.serialization.JsonSerializable
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import com.squareup.moshi.Moshi
@@ -12,9 +13,9 @@ import org.junit.Test
 class MoshiJsonWebSocketDecoratorTest {
 
     @Suppress("unused")
-    class TypeOut(val fieldA: String, val fieldB: Int)
+    class TypeOut(val fieldA: String, val fieldB: Int) : JsonSerializable
 
-    data class TypeIn(val fieldC: String, val fieldD: Int)
+    data class TypeIn(val fieldC: String, val fieldD: Int) : JsonSerializable
 
     private val moshi = Moshi.Builder().build()
 

--- a/common/network/src/test/kotlin/com/blockchain/network/websocket/OkHttpWebSocketJsonIntegrationTest.kt
+++ b/common/network/src/test/kotlin/com/blockchain/network/websocket/OkHttpWebSocketJsonIntegrationTest.kt
@@ -1,6 +1,7 @@
 package com.blockchain.network.websocket
 
 import com.blockchain.network.initRule
+import com.blockchain.serialization.JsonSerializable
 import com.squareup.moshi.Moshi
 import io.fabric8.mockwebserver.DefaultMockServer
 import okhttp3.OkHttpClient
@@ -11,9 +12,9 @@ import org.junit.Test
 class OkHttpWebSocketJsonIntegrationTest {
 
     @Suppress("unused")
-    class ClientMessage(val data1: String, val data2: Int)
+    class ClientMessage(val data1: String, val data2: Int) : JsonSerializable
 
-    data class ServerMessage(val data3: String, val data4: Int)
+    data class ServerMessage(val data3: String, val data4: Int) : JsonSerializable
 
     private val server = DefaultMockServer()
 


### PR DESCRIPTION
- Implementing JsonSerializable is an easy way to get proguard keeping and additional instance and class extension methods, so I'm enforcing it on the new Json Web Socket.