### PR TITLE
feat(HomeBrew): AND-1386 Trade detail

### DIFF
--- a/morph/ui/src/main/java/com/blockchain/morph/ui/homebrew/exchange/detail/HomebrewTradeDetailActivity.kt
+++ b/morph/ui/src/main/java/com/blockchain/morph/ui/homebrew/exchange/detail/HomebrewTradeDetailActivity.kt
@@ -14,13 +14,14 @@ class HomebrewTradeDetailActivity : BaseAuthActivity() {
         setContentView(R.layout.activity_homebrew_trade_detail)
 
         val trade = intent.extras.get("EXTRA_TRADE") as Trade
-        setupToolbar(R.id.toolbar_constraint, trade.id)
+        setupToolbar(R.id.toolbar_constraint, R.string.order_detail)
 
         // TODO: data to test layout - use real object
         status.text = trade.state
         value.text = trade.depositQuantity
         receive.text = trade.quantity
         fees.text = trade.price
+        trade_id.text = trade.id
     }
 
     override fun onSupportNavigateUp(): Boolean = consume { onBackPressed() }

--- a/morph/ui/src/main/res/layout/activity_homebrew_trade_detail.xml
+++ b/morph/ui/src/main/res/layout/activity_homebrew_trade_detail.xml
@@ -190,5 +190,54 @@
         app:layout_constraintStart_toStartOf="@+id/guideline"
         app:layout_constraintTop_toBottomOf="@+id/receive"
         tools:text="My Wallet" />
+    <TextView
+        android:id="@+id/trade_id_title"
+        android:layout_width="0dp"
+        android:layout_height="58dp"
+        android:layout_marginTop="2dp"
+        android:background="@color/trade_row_background"
+        android:fontFamily="@font/montserrat"
+        android:gravity="center_vertical"
+        android:padding="16dp"
+        android:textColor="@color/exchange_text_gray_color"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toStartOf="@+id/guideline"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/send_to_title"
+        android:text="@string/morph_order_id_title" />
+
+    <TextView
+        android:id="@+id/trade_id"
+        android:layout_width="0dp"
+        android:layout_height="58dp"
+        android:layout_gravity="end"
+        android:layout_marginTop="2dp"
+        android:background="@color/trade_row_background"
+        android:fontFamily="@font/montserrat"
+        android:gravity="center_vertical|end"
+        android:padding="16dp"
+        android:textColor="@color/exchange_text_dark_color"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
+        app:layout_constraintTop_toBottomOf="@+id/send_to"
+        tools:text="ede39566-1f0d-4e48-96fa-b558b70e46b7" />
+
+    <TextView
+        android:id="@+id/status_detail_textView"
+        android:layout_width="0dp"
+        android:layout_height="32dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="16dp"
+        android:gravity="center"
+        android:text="@string/status_inprogress_detail"
+        android:textAlignment="center"
+        android:textColor="@color/exchange_text_gray_color"
+        android:textSize="12sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/trade_id"
+        tools:text="Thanks for placing your trade! Funds will usually reach your wallet within 2 hours and we’ll wend you a notification when that happens. Keep track of your trade’s progress in the Order History area." />
 
 </android.support.constraint.ConstraintLayout>

--- a/morph/ui/src/main/res/values/strings.xml
+++ b/morph/ui/src/main/res/values/strings.xml
@@ -74,11 +74,17 @@
     <string name="receive">Receive</string>
     <string name="fees">Fees</string>
     <string name="value">Value</string>
+    <string name="order_detail">Order Detail</string>
     <string name="make_a_new_exchange">Make a New Exchange</string>
     <string name="order_history">Order History</string>
     <string name="no_orders_found">No Orders Found</string>
     <string name="done">Done</string>
     <string name="confirm_exchange">Confirm Exchange</string>
     <string name="exchange_locked">Exchange Locked</string>
+    <string name="status_inprogress_detail">Thanks for placing your trade! Funds will usually reach your wallet within 2 hours and we’ll wend you a notification when that happens. Keep track of your trade’s progress in the Order History area.</string>
+    <string name="status_failed_detail">We have refunded your wallet after the trade failed. Please return to the exchange tab to start a new trade.</string>
+    <string name="status_refund_inprogress_detail">We are now processing a refund for any funds broadcast minus the network fee. Please check your Order History to check the refund status.</string>
+    <string name="status_refunded_detail">Exchange Locked</string>
+    <string name="status_expired_detail">Your trade has expired. Any funds broadcast from your wallet will be returned minus the network fee. Contact User Support with your Order ID to request a refund.</string>
 
 </resources>


### PR DESCRIPTION
Trade detail, Order ID removed from toolbar ad added as new row
Status explained text added to screen and strings. 
TODO: populate the screen with real data from endpoint + change the status text according to the order status.