### PR TITLE
feat(HomeBrew): AND-1350 Disable Exchange button when a quote is not valid

### DIFF
--- a/morph/common/src/main/java/com/blockchain/morph/exchange/mvi/ExchangeViewModel.kt
+++ b/morph/common/src/main/java/com/blockchain/morph/exchange/mvi/ExchangeViewModel.kt
@@ -13,6 +13,11 @@ data class ExchangeViewModel(
     val to: Value,
     val latestQuote: Quote? = null
 ) {
+    fun isValid(): Boolean =
+        latestQuote != null &&
+        latestQuote.fix == fixedField &&
+        latestQuote.fixValue == fixedMoneyValue
+
     val fromCryptoCurrency = fromAccount.cryptoCurrency
     val toCryptoCurrency = toAccount.cryptoCurrency
 }

--- a/morph/common/src/test/java/com/blockchain/morph/exchange/mvi/ExchangeViewModelValidityTest.kt
+++ b/morph/common/src/test/java/com/blockchain/morph/exchange/mvi/ExchangeViewModelValidityTest.kt
@@ -58,7 +58,6 @@ class ExchangeViewModelValidityTest {
         ).isValid() `should be` false
     }
 
-
     @Test
     fun `is not valid if the value doesn't match`() {
         ExchangeViewModel(

--- a/morph/common/src/test/java/com/blockchain/morph/exchange/mvi/ExchangeViewModelValidityTest.kt
+++ b/morph/common/src/test/java/com/blockchain/morph/exchange/mvi/ExchangeViewModelValidityTest.kt
@@ -1,0 +1,79 @@
+package com.blockchain.morph.exchange.mvi
+
+import com.blockchain.testutils.ether
+import com.blockchain.testutils.gbp
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.mock
+import org.junit.Test
+
+class ExchangeViewModelValidityTest {
+
+    @Test
+    fun `is valid - base crypto`() {
+        ExchangeViewModel(
+            fromAccount = mock(),
+            toAccount = mock(),
+            from = value(
+                userEntered(10.ether()),
+                upToDate(25.gbp())
+            ),
+            to = mock(),
+            latestQuote = Quote(
+                fix = Fix.BASE_CRYPTO,
+                from = Quote.Value(cryptoValue = 10.ether(), fiatValue = mock()),
+                to = mock()
+            )
+        ).isValid() `should be` true
+    }
+
+    @Test
+    fun `is not valid without a quote`() {
+        ExchangeViewModel(
+            fromAccount = mock(),
+            toAccount = mock(),
+            from = value(
+                userEntered(10.ether()),
+                upToDate(25.gbp())
+            ),
+            to = mock(),
+            latestQuote = null
+        ).isValid() `should be` false
+    }
+
+    @Test
+    fun `is not valid if the fix doesn't match`() {
+        ExchangeViewModel(
+            fromAccount = mock(),
+            toAccount = mock(),
+            from = value(
+                userEntered(10.ether()),
+                upToDate(25.gbp())
+            ),
+            to = mock(),
+            latestQuote = Quote(
+                fix = Fix.COUNTER_CRYPTO,
+                from = mock(),
+                to = Quote.Value(cryptoValue = 10.ether(), fiatValue = mock())
+            )
+        ).isValid() `should be` false
+    }
+
+
+    @Test
+    fun `is not valid if the value doesn't match`() {
+        ExchangeViewModel(
+            fromAccount = mock(),
+            toAccount = mock(),
+            from = value(
+                userEntered(10.ether()),
+                upToDate(25.gbp())
+            ),
+            to = mock(),
+            latestQuote = Quote(
+                fix = Fix.BASE_CRYPTO,
+                from = Quote.Value(cryptoValue = 9.ether(), fiatValue = mock()),
+                to = mock()
+            )
+        ).isValid() `should be` false
+    }
+}

--- a/morph/ui/src/main/java/com/blockchain/morph/ui/homebrew/exchange/ExchangeFragment.kt
+++ b/morph/ui/src/main/java/com/blockchain/morph/ui/homebrew/exchange/ExchangeFragment.kt
@@ -156,6 +156,7 @@ internal class ExchangeFragment : Fragment() {
                     it.fromAccount.cryptoCurrency.symbol,
                     it.toAccount.cryptoCurrency.symbol
                 )
+                exchangeButton.isEnabled = it.isValid()
             }
         compositeDisposable += keyboard.viewStates
             .subscribeBy {

--- a/morph/ui/src/main/res/drawable/exchange_button_background.xml
+++ b/morph/ui/src/main/res/drawable/exchange_button_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/exchange_button_blue" android:state_enabled="true" />
+    <item android:drawable="@color/exchange_button_blue_disabled" android:state_enabled="false" />
+    <item android:drawable="@color/exchange_button_blue" />
+</selector>

--- a/morph/ui/src/main/res/drawable/exchange_button_background.xml
+++ b/morph/ui/src/main/res/drawable/exchange_button_background.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@color/exchange_button_blue" android:state_enabled="true" />
-    <item android:drawable="@color/exchange_button_blue_disabled" android:state_enabled="false" />
-    <item android:drawable="@color/exchange_button_blue" />
-</selector>

--- a/morph/ui/src/main/res/layout/fragment_homebrew_exchange.xml
+++ b/morph/ui/src/main/res/layout/fragment_homebrew_exchange.xml
@@ -149,7 +149,6 @@
         android:layout_marginBottom="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
-        android:background="@drawable/exchange_button_background"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/morph/ui/src/main/res/layout/fragment_homebrew_exchange.xml
+++ b/morph/ui/src/main/res/layout/fragment_homebrew_exchange.xml
@@ -149,7 +149,7 @@
         android:layout_marginBottom="16dp"
         android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
-        android:background="#FF10ADE4"
+        android:background="@drawable/exchange_button_background"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/morph/ui/src/main/res/values/exchange_styles.xml
+++ b/morph/ui/src/main/res/values/exchange_styles.xml
@@ -7,6 +7,9 @@
 
     <color name="exchange_blue">#FF004A7C</color>
 
+    <color name="exchange_button_blue">#FF10ADE4</color>
+    <color name="exchange_button_blue_disabled">#FFADADAD</color>
+
     <style name="ExchangeText">
         <item name="android:fontFamily">Montserrat</item>
     </style>

--- a/morph/ui/src/main/res/values/exchange_styles.xml
+++ b/morph/ui/src/main/res/values/exchange_styles.xml
@@ -7,15 +7,11 @@
 
     <color name="exchange_blue">#FF004A7C</color>
 
-    <color name="exchange_button_blue">#FF10ADE4</color>
-    <color name="exchange_button_blue_disabled">#FFADADAD</color>
-
     <style name="ExchangeText">
         <item name="android:fontFamily">Montserrat</item>
     </style>
 
-    <style name="ExchangeButton" parent="@android:style/Widget.Button">
-        <item name="android:fontFamily">Montserrat</item>
+    <style name="ExchangeButton" parent="@style/ButtonStyle">
         <item name="android:textAllCaps">true</item>
     </style>
 
@@ -49,8 +45,7 @@
     </style>
 
     <style name="ExchangeButton.Exchange">
-        <item name="android:textColor">#FFFFFFFF</item>
-        <item name="android:textSize">17sp</item>
+        <item name="android:theme">@style/LightBlueButtonTheme</item>
     </style>
 
     <!-- keyboard -->


### PR DESCRIPTION
- Button is disabled and grey when the last quote doesn't match the value the user has typed.
- This happens when the quote has not yet been returned
- Or the quote was unable to be returned for whatever reason

![image](https://user-images.githubusercontent.com/6041352/45963409-04ae9380-c01b-11e8-970c-bb3fbaf8458d.png)
