### PR TITLE
fix(Metadata): AND-909 Ensure that the Koin objects are being used rather than having Dagger recreate them too. Migrate some schedulers and update some logging.

### DIFF
--- a/app/src/main/java/piuk/blockchain/android/injection/ApplicationModule.java
+++ b/app/src/main/java/piuk/blockchain/android/injection/ApplicationModule.java
@@ -7,15 +7,12 @@ import com.blockchain.koin.modules.MorphActivityLauncher;
 import com.blockchain.kyc.datamanagers.nabu.NabuDataManager;
 import com.blockchain.kycui.settings.KycStatusHelper;
 import com.blockchain.network.EnvironmentUrls;
-import com.google.firebase.iid.FirebaseInstanceId;
+import com.blockchain.notifications.NotificationTokenManager;
 import dagger.Module;
 import dagger.Provides;
-import info.blockchain.wallet.api.WalletApi;
 import info.blockchain.wallet.payload.PayloadManager;
 import info.blockchain.wallet.payload.PayloadManagerWiper;
 import info.blockchain.wallet.util.PrivateKeyFactory;
-import com.blockchain.notifications.NotificationService;
-import com.blockchain.notifications.NotificationTokenManager;
 import piuk.blockchain.android.util.PrngHelper;
 import piuk.blockchain.androidcore.data.access.AccessState;
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig;
@@ -23,9 +20,9 @@ import piuk.blockchain.androidcore.data.bitcoincash.BchDataManager;
 import piuk.blockchain.androidcore.data.currency.CurrencyState;
 import piuk.blockchain.androidcore.data.ethereum.EthDataManager;
 import piuk.blockchain.androidcore.data.fees.FeeDataManager;
+import piuk.blockchain.androidcore.data.metadata.MetadataManager;
+import piuk.blockchain.androidcore.data.payload.PayloadDataManager;
 import piuk.blockchain.androidcore.data.payments.SendDataManager;
-import piuk.blockchain.androidcore.data.rxjava.RxBus;
-import piuk.blockchain.androidcore.utils.PrefsUtil;
 import piuk.blockchain.androidcore.utils.PrngFixer;
 
 import javax.inject.Named;
@@ -64,6 +61,11 @@ public class ApplicationModule extends KoinDaggerModule {
     @Named("explorer-url")
     String provideExplorerUrl() {
         return get(String.class, "explorer-url");
+    }
+
+    @Provides
+    PayloadDataManager providePayloadDataManager() {
+        return get(PayloadDataManager.class);
     }
 
     @Provides
@@ -130,6 +132,11 @@ public class ApplicationModule extends KoinDaggerModule {
     @Provides
     FeeDataManager provideFeeDataManager() {
         return get(FeeDataManager.class);
+    }
+
+    @Provides
+    MetadataManager provideMetadataManager() {
+        return get(MetadataManager.class);
     }
 
 

--- a/app/src/main/java/piuk/blockchain/android/ui/balance/BalancePresenter.kt
+++ b/app/src/main/java/piuk/blockchain/android/ui/balance/BalancePresenter.kt
@@ -170,6 +170,7 @@ class BalancePresenter @Inject constructor(
 
     @VisibleForTesting
     internal fun updateBchWallet() = bchDataManager.refreshMetadataCompletable()
+        .subscribeOn(Schedulers.io())
         .doOnError { Timber.e(it) }
 
     /**

--- a/app/src/main/java/piuk/blockchain/android/ui/home/MainPresenter.java
+++ b/app/src/main/java/piuk/blockchain/android/ui/home/MainPresenter.java
@@ -253,8 +253,8 @@ public class MainPresenter extends BasePresenter<MainView> {
                 .andThen(shapeshiftCompletable())
                 .andThen(bchCompletable())
                 .andThen(feesCompletable())
+                .observeOn(AndroidSchedulers.mainThread())
                 .doAfterTerminate(() -> {
-                            doWalletOptionsChecks();
                             getView().hideProgressDialog();
 
                             initPrompts(getView().getActivityContext());
@@ -267,6 +267,7 @@ public class MainPresenter extends BasePresenter<MainView> {
                         }
                 )
                 .subscribe(ignore -> {
+                    doWalletOptionsChecks();
                     if (getView().isBuySellPermitted()) {
                         initBuyService();
                     } else {
@@ -295,7 +296,7 @@ public class MainPresenter extends BasePresenter<MainView> {
                 .doOnError(throwable -> {
                     Logging.INSTANCE.logException(throwable);
                     // TODO: 21/02/2018 Reload or disable?
-                    Timber.e("Failed to load bch wallet");
+                    Timber.e(throwable, "Failed to load bch wallet");
                 });
     }
 
@@ -306,7 +307,7 @@ public class MainPresenter extends BasePresenter<MainView> {
                 .doOnError(throwable -> {
                     Logging.INSTANCE.logException(throwable);
                     // TODO: 21/02/2018 Reload or disable?
-                    Timber.e("Failed to load eth wallet");
+                    Timber.e(throwable, "Failed to load eth wallet");
                 });
     }
 
@@ -316,7 +317,7 @@ public class MainPresenter extends BasePresenter<MainView> {
                 .doOnError(throwable -> {
                     Logging.INSTANCE.logException(throwable);
                     // TODO: 21/02/2018 Reload or disable?
-                    Timber.e("Failed to load shape shift trades");
+                    Timber.e(throwable, "Failed to load shape shift trades");
                 });
     }
 

--- a/core/src/main/java/piuk/blockchain/androidcore/data/bitcoincash/BchDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/bitcoincash/BchDataManager.kt
@@ -12,6 +12,7 @@ import info.blockchain.wallet.multiaddress.TransactionSummary
 import info.blockchain.wallet.payload.data.isArchived
 import io.reactivex.Completable
 import io.reactivex.Observable
+import io.reactivex.schedulers.Schedulers
 import piuk.blockchain.android.util.StringUtils
 import piuk.blockchain.androidcore.R
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
@@ -85,7 +86,7 @@ class BchDataManager(
                         Completable.complete()
                     }
                 }
-        }.applySchedulers()
+        }.subscribeOn(Schedulers.io())
 
     /**
      * Refreshes bitcoin cash metadata. Useful if another platform performed any changes to wallet state.
@@ -102,10 +103,8 @@ class BchDataManager(
     internal fun fetchMetadata(
         defaultLabel: String,
         accountTotal: Int
-    ): Observable<Optional<GenericMetadataWallet>> {
-
-        return metadataManager.fetchMetadata(BitcoinCashWallet.METADATA_TYPE_EXTERNAL)
-            .applySchedulers()
+    ): Observable<Optional<GenericMetadataWallet>> =
+        metadataManager.fetchMetadata(BitcoinCashWallet.METADATA_TYPE_EXTERNAL)
             .map { optional ->
 
                 if (optional.isPresent) {
@@ -134,7 +133,6 @@ class BchDataManager(
                     Optional.absent()
                 }
             }
-    }
 
     @VisibleForTesting
     internal fun createMetadata(defaultLabel: String, accountTotal: Int): GenericMetadataWallet {

--- a/core/src/main/java/piuk/blockchain/androidcore/data/ethereum/EthDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/ethereum/EthDataManager.kt
@@ -13,6 +13,7 @@ import info.blockchain.wallet.payload.PayloadManager
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.functions.BiFunction
+import io.reactivex.schedulers.Schedulers
 import org.bitcoinj.core.ECKey
 import org.spongycastle.util.encoders.Hex
 import org.web3j.crypto.RawTransaction
@@ -222,7 +223,7 @@ class EthDataManager(
                         Completable.complete()
                     }
                 }
-        }.applySchedulers()
+        }.observeOn(Schedulers.io())
 
     /**
      * @param gasPrice Represents the fee the sender is willing to pay for gas. One unit of gas
@@ -278,7 +279,6 @@ class EthDataManager(
     @Throws(Exception::class)
     private fun fetchOrCreateEthereumWallet(defaultLabel: String) =
         metadataManager.fetchMetadata(EthereumWallet.METADATA_TYPE_EXTERNAL)
-            .applySchedulers()
             .map { optional ->
 
                 val walletJson = optional.orNull()

--- a/core/src/main/java/piuk/blockchain/androidcore/data/payload/PayloadDataManager.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/payload/PayloadDataManager.kt
@@ -22,17 +22,14 @@ import org.spongycastle.crypto.InvalidCipherTextException
 import piuk.blockchain.androidcore.data.api.EnvironmentConfig
 import piuk.blockchain.androidcore.data.rxjava.RxBus
 import piuk.blockchain.androidcore.data.rxjava.RxPinning
-import piuk.blockchain.androidcore.injection.PresenterScope
 import piuk.blockchain.androidcore.utils.extensions.applySchedulers
 import piuk.blockchain.androidcore.utils.rxjava.IgnorableDefaultObserver
 import java.io.UnsupportedEncodingException
 import java.math.BigInteger
 import java.util.ArrayList
 import java.util.LinkedHashMap
-import javax.inject.Inject
 
-@PresenterScope
-class PayloadDataManager @Inject constructor(
+class PayloadDataManager(
     private val payloadService: PayloadService,
     private val privateKeyFactory: PrivateKeyFactory,
     private val payloadManager: PayloadManager,

--- a/core/src/main/java/piuk/blockchain/androidcore/data/payload/PayloadService.kt
+++ b/core/src/main/java/piuk/blockchain/androidcore/data/payload/PayloadService.kt
@@ -17,9 +17,8 @@ import org.bitcoinj.core.NetworkParameters
 import piuk.blockchain.androidcore.utils.annotations.WebRequest
 import piuk.blockchain.androidcore.utils.rxjava.IgnorableDefaultObserver
 import java.util.LinkedHashMap
-import javax.inject.Inject
 
-class PayloadService @Inject constructor(private val payloadManager: PayloadManager) {
+class PayloadService(private val payloadManager: PayloadManager) {
 
     // /////////////////////////////////////////////////////////////////////////
     // AUTH METHODS

--- a/morph/shapeshift/src/main/java/piuk/blockchain/androidcore/data/shapeshift/ShapeShiftDataManager.kt
+++ b/morph/shapeshift/src/main/java/piuk/blockchain/androidcore/data/shapeshift/ShapeShiftDataManager.kt
@@ -19,6 +19,7 @@ import com.blockchain.morph.CoinPair
 import piuk.blockchain.androidcore.injection.PresenterScope
 import piuk.blockchain.androidcore.utils.Either
 import com.blockchain.utils.Optional
+import io.reactivex.schedulers.Schedulers
 import piuk.blockchain.androidcore.utils.annotations.WebRequest
 import piuk.blockchain.androidcore.utils.extensions.applySchedulers
 import javax.inject.Inject
@@ -51,7 +52,7 @@ class ShapeShiftDataManager @Inject constructor(
                     } else {
                         Completable.complete()
                     }
-                }.applySchedulers()
+                }.subscribeOn(Schedulers.io())
         }
 
     /**
@@ -280,7 +281,6 @@ class ShapeShiftDataManager @Inject constructor(
     @Throws(Exception::class)
     private fun fetchOrCreateShapeShiftTradeData(): Observable<Pair<ShapeShiftTrades, Boolean>> =
         metadataManager.fetchMetadata(ShapeShiftTrades.METADATA_TYPE_EXTERNAL)
-            .applySchedulers()
             .map { optional ->
 
                 val json = optional.orNull()


### PR DESCRIPTION
I was consistently seeing errors fetching metadata on first login when creating a new wallet, due to the wallet body being empty - which didn't make any sense. Here I've ensured that we're using Koin to construct all of the related classes and now I'm not seeing any issues.