### PR TITLE
Fixed.

### DIFF
--- a/wallet/src/main/java/info/blockchain/wallet/util/FormatsUtil.kt
+++ b/wallet/src/main/java/info/blockchain/wallet/util/FormatsUtil.kt
@@ -159,6 +159,7 @@ object FormatsUtil {
 
     const val BTC_PREFIX = "bitcoin:"
     const val BCH_PREFIX = "bitcoincash:"
+    const val ETHEREUM_PREFIX = "ethereum:"
 
     fun toDisambiguatedBtcAddress(
         address: String


### PR DESCRIPTION
## Objective

Fixed issue with QR code scanning for ETH with amount,

## Description

Modified EthAsset.

## How to Test

Generate and scan the following QR: ethereum:0x0a62e9a9e133924e66ef918d4352e93ba31d0676?value=4490000000000000&gasPrice=68000000000

## Screenshot/Design assessment

*If the change is UI related, paste a screenshot here and include an assessment of design accuracy if applicable.*

## Merge Checklist

- [ ] The PR uses a title supported by [.changelogrc](https://github.com/blockchain/My-Wallet-V3-iOS/blob/dev/.changelogrc#L6...L69).
- [ ] You have added unit tests.
- [ ] You have added `contentDescription` tags to new Views
- [ ] You have added sufficient documentation (descriptive comments).
